### PR TITLE
Rename context and hooks, EditorView -> Editor

### DIFF
--- a/.yarn/versions/4c3fc6bb.yml
+++ b/.yarn/versions/4c3fc6bb.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@nytimes/react-prosemirror"

--- a/src/components/ProseMirrorInner.tsx
+++ b/src/components/ProseMirrorInner.tsx
@@ -2,7 +2,7 @@ import type { DirectEditorProps } from "prosemirror-view";
 import React from "react";
 import type { ReactNode } from "react";
 
-import { EditorViewContext } from "../contexts/EditorViewContext.js";
+import { EditorContext } from "../contexts/EditorContext.js";
 import { useEditorView } from "../hooks/useEditorView.js";
 
 export type ProseMirrorProps = DirectEditorProps & {
@@ -45,8 +45,8 @@ export function ProseMirrorInner({
   });
 
   return (
-    <EditorViewContext.Provider value={{ editorView, editorState: state }}>
+    <EditorContext.Provider value={{ editorView, editorState: state }}>
       {children ?? null}
-    </EditorViewContext.Provider>
+    </EditorContext.Provider>
   );
 }

--- a/src/contexts/EditorContext.ts
+++ b/src/contexts/EditorContext.ts
@@ -2,7 +2,7 @@ import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { createContext } from "react";
 
-interface EditorViewContextValue {
+interface EditorContextValue {
   editorView: EditorView | null;
   editorState: EditorState | null;
 }
@@ -13,6 +13,6 @@ interface EditorViewContextValue {
  * see `useEditorState`, `useEditorViewEvent`, and
  * `useEditorViewLayoutEffect`.
  */
-export const EditorViewContext = createContext(
-  null as unknown as EditorViewContextValue
+export const EditorContext = createContext(
+  null as unknown as EditorContextValue
 );

--- a/src/hooks/__tests__/useEditorViewLayoutEffect.test.tsx
+++ b/src/hooks/__tests__/useEditorViewLayoutEffect.test.tsx
@@ -3,9 +3,9 @@ import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import React from "react";
 
-import { EditorViewContext } from "../../contexts/EditorViewContext.js";
+import { EditorContext } from "../../contexts/EditorContext.js";
 import { LayoutGroup } from "../../contexts/LayoutGroup.js";
-import { useEditorViewLayoutEffect } from "../useEditorViewLayoutEffect.js";
+import { useEditorEffect } from "../useEditorEffect.js";
 
 function TestComponent({
   effect,
@@ -14,7 +14,7 @@ function TestComponent({
   effect: () => void;
   dependencies?: unknown[];
 }) {
-  useEditorViewLayoutEffect(effect, [effect, ...dependencies]);
+  useEditorEffect(effect, [effect, ...dependencies]);
   return null;
 }
 
@@ -26,9 +26,9 @@ describe("useEditorViewLayoutEffect", () => {
 
     render(
       <LayoutGroup>
-        <EditorViewContext.Provider value={{ editorView, editorState }}>
+        <EditorContext.Provider value={{ editorView, editorState }}>
           <TestComponent effect={effect} />
-        </EditorViewContext.Provider>
+        </EditorContext.Provider>
       </LayoutGroup>
     );
 
@@ -43,17 +43,17 @@ describe("useEditorViewLayoutEffect", () => {
 
     const { rerender } = render(
       <LayoutGroup>
-        <EditorViewContext.Provider value={{ editorView, editorState }}>
+        <EditorContext.Provider value={{ editorView, editorState }}>
           <TestComponent effect={effect} dependencies={[]} />
-        </EditorViewContext.Provider>
+        </EditorContext.Provider>
       </LayoutGroup>
     );
 
     rerender(
       <LayoutGroup>
-        <EditorViewContext.Provider value={{ editorView, editorState }}>
+        <EditorContext.Provider value={{ editorView, editorState }}>
           <TestComponent effect={effect} dependencies={[]} />
-        </EditorViewContext.Provider>
+        </EditorContext.Provider>
       </LayoutGroup>
     );
 
@@ -67,17 +67,17 @@ describe("useEditorViewLayoutEffect", () => {
 
     const { rerender } = render(
       <LayoutGroup>
-        <EditorViewContext.Provider value={{ editorView, editorState }}>
+        <EditorContext.Provider value={{ editorView, editorState }}>
           <TestComponent effect={effect} dependencies={["one"]} />
-        </EditorViewContext.Provider>
+        </EditorContext.Provider>
       </LayoutGroup>
     );
 
     rerender(
       <LayoutGroup>
-        <EditorViewContext.Provider value={{ editorView, editorState }}>
+        <EditorContext.Provider value={{ editorView, editorState }}>
           <TestComponent effect={effect} dependencies={["two"]} />
-        </EditorViewContext.Provider>
+        </EditorContext.Provider>
       </LayoutGroup>
     );
 

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -2,7 +2,7 @@ import type { EditorView } from "prosemirror-view";
 import { useContext } from "react";
 import type { DependencyList } from "react";
 
-import { EditorViewContext } from "../contexts/EditorViewContext.js";
+import { EditorContext } from "../contexts/EditorContext.js";
 import { useLayoutGroupEffect } from "../contexts/LayoutGroup.js";
 
 /**
@@ -19,11 +19,11 @@ import { useLayoutGroupEffect } from "../contexts/LayoutGroup.js";
  * _after_ the EditorView has been updated, even when the
  * EditorView lives in an ancestor component.
  */
-export function useEditorViewLayoutEffect(
+export function useEditorEffect(
   effect: (editorView: EditorView | null) => void | (() => void),
   dependencies?: DependencyList
 ) {
-  const { editorView } = useContext(EditorViewContext);
+  const { editorView } = useContext(EditorContext);
 
   // The rules of hooks want `effect` to be included in the
   // dependency list, but dependency issues for `effect` will

--- a/src/hooks/useEditorEvent.ts
+++ b/src/hooks/useEditorEvent.ts
@@ -1,9 +1,9 @@
 import type { EditorView } from "prosemirror-view";
 import { useCallback, useContext, useRef } from "react";
 
-import { EditorViewContext } from "../contexts/EditorViewContext.js";
+import { EditorContext } from "../contexts/EditorContext.js";
 
-import { useEditorViewLayoutEffect } from "./useEditorViewLayoutEffect.js";
+import { useEditorEffect } from "./useEditorEffect.js";
 
 /**
  * Returns a stable function reference to be used as an
@@ -18,13 +18,13 @@ import { useEditorViewLayoutEffect } from "./useEditorViewLayoutEffect.js";
  * component that is mounted as a child of both of these
  * providers.
  */
-export function useEditorViewEvent<T extends unknown[]>(
+export function useEditorEvent<T extends unknown[]>(
   callback: (view: EditorView | null, ...args: T) => void
 ) {
   const ref = useRef(callback);
-  const { editorView } = useContext(EditorViewContext);
+  const { editorView } = useContext(EditorContext);
 
-  useEditorViewLayoutEffect(() => {
+  useEditorEffect(() => {
     ref.current = callback;
   }, [callback]);
 

--- a/src/hooks/useEditorState.ts
+++ b/src/hooks/useEditorState.ts
@@ -1,13 +1,13 @@
 import type { EditorState } from "prosemirror-state";
 import { useContext } from "react";
 
-import { EditorViewContext } from "../contexts/EditorViewContext.js";
+import { EditorContext } from "../contexts/EditorContext.js";
 
 /**
  * Provides access to the current EditorState value.
  */
 export function useEditorState(): EditorState | null {
-  const { editorState } = useContext(EditorViewContext);
+  const { editorState } = useContext(EditorContext);
 
   return editorState;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 export * from "./components/ProseMirror.js";
-export * from "./contexts/EditorViewContext.js";
+export * from "./contexts/EditorContext.js";
 export * from "./contexts/LayoutGroup.js";
 export * from "./hooks/useEditorState.js";
 export * from "./hooks/useEditorView.js";
-export * from "./hooks/useEditorViewEvent.js";
-export * from "./hooks/useEditorViewLayoutEffect.js";
+export * from "./hooks/useEditorEvent.js";
+export * from "./hooks/useEditorEffect.js";
 export * from "./hooks/useNodeViews.js";
 
 export type { NodeViewComponentProps } from "./nodeViews/createReactNodeViewConstructor";


### PR DESCRIPTION
Closes #8, #10.

See discussion in issues for more info, but this is just a simple rename!