### PR TITLE
Add top-level types field to package.json

### DIFF
--- a/.yarn/versions/e7a26c1d.yml
+++ b/.yarn/versions/e7a26c1d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Typescript has support for the `"types"` field in Node.js's Conditional Exports object (which we specify), but only for very new versions of Typescript. So this PR adds the types the "old" way, too, as a fallback.

Typescript documentation for reference: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing