### PR TITLE
0.1.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,4 +29,6 @@ jobs:
         run: yarn check:types
 
       - name: Version
-        run: ./scripts/if-no-version-change.sh yarn version check
+        run:
+          git fetch origin main --depth 1 && ./scripts/if-no-version-change.sh
+          yarn version check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,4 +29,4 @@ jobs:
         run: yarn check:types
 
       - name: Version
-        run: yarn version check
+        run: ./scripts/if-no-version-change.sh yarn version check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn version check
+./scripts/if-no-version-change.sh yarn version check

--- a/.yarn/versions/28e691ab.yml
+++ b/.yarn/versions/28e691ab.yml
@@ -1,2 +1,0 @@
-declined:
-  - "@nytimes/react-prosemirror"

--- a/.yarn/versions/3260a02e.yml
+++ b/.yarn/versions/3260a02e.yml
@@ -1,2 +1,0 @@
-declined:
-  - "@nytimes/react-prosemirror"

--- a/.yarn/versions/4c3fc6bb.yml
+++ b/.yarn/versions/4c3fc6bb.yml
@@ -1,2 +1,0 @@
-declined:
-  - "@nytimes/react-prosemirror"

--- a/.yarn/versions/87656097.yml
+++ b/.yarn/versions/87656097.yml
@@ -1,2 +1,0 @@
-declined:
-  - "@nytimes/react-prosemirror"

--- a/.yarn/versions/e7a26c1d.yml
+++ b/.yarn/versions/e7a26c1d.yml
@@ -1,2 +1,0 @@
-releases:
-  "@nytimes/react-prosemirror": patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,16 @@ And you can build output files with `yarn build`.
 You can run tests with `yarn test`. If you want to run tests in "watch" mode,
 use `yarn test -w`. See the [Jest CLI docs](https://jestjs.io/docs/cli) for more
 information.
+
+## Version management
+
+We use yarn's "deferred versioning" release flow, documented
+[here](https://yarnpkg.com/features/release-workflow#deferred-versioning). For
+any change that affects source code files, developers will be asked at
+`git push` time to use `yarn version check -i` to specify what kind of change
+(`patch`, `minor`, or `major`) is contained within the release. This version
+type will be documented in the form of a new YAML file added to the
+`.yarn/versions` directory, which can be reviewed during code review.
+
+Maintainers can then later use `yarn version apply --all` to aggregate the
+proposed version bumps and apply them to the `package.json` file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nytimes/react-prosemirror",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/scripts/if-no-version-change.sh
+++ b/scripts/if-no-version-change.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if git diff main -- package.json | grep -e '^+ *"version":'
+if git diff origin/main -- package.json | grep -e '^+ *"version":'
 then
   echo "Not checking version; version was changed in this branch"
 else

--- a/scripts/if-no-version-change.sh
+++ b/scripts/if-no-version-change.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if git diff main -- package.json | grep -e '^+ *"version":'
+then
+  echo "Not checking version; version was changed in this branch"
+else
+  "$@"
+fi


### PR DESCRIPTION
Turns out, `yarn version apply` is a little broken! There are some kinks to be worked out for sure. Some things that I've learned:

The `--all` flag is meant to only apply to monorepos; in theory, in a single-project repo, it shouldn't be necessary. In practice, if you don't include `--all`, `yarn version apply` doesn't actually delete any version files, it just clears out the contents of any (except for `declined` bumps, which it doesn't seem to know how to handle). To work around this, we just always should use `--all` (as noted in the new Version Bump docs), which works fine on single-project repos.

Additionally, `yarn version check` kind of explodes if you run it after having run `yarn version apply --all`, because `yarn version check` kind of explodes if you modify more than one version file in a branch, and `yarn version apply --all` deletes all of the version files! To work around _this_, I introduced a new, dumb bash script that only runs the command you pass it if `package.json`'s version field hasn't been updated on this branch. This way we can simply run `./scripts/if-no-version-change.sh yarn version check` in our pre-push hook to avoid running `yarn version check` if `yarn version apply --all` has already been run!

Finally, of course, this PR actually bumps the version to 0.1.1!