### PR TITLE
Clean up console.logs and missing file extensions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "node": false
   },
   "rules": {
+    "no-console": ["off", { "allow": "error" }],
     "react-hooks/exhaustive-deps": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,10 @@
 {
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
+    "plugin:import/typescript",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "prettier"
@@ -18,9 +20,10 @@
     "react-hooks/exhaustive-deps": [
       "warn",
       {
-        "additionalHooks": "(useEditorViewLayoutEffect|useEditorViewEvent|useDeferredLayoutEffect$)"
+        "additionalHooks": "(useEditorEffect|useLayoutGroupEffect$)"
       }
     ],
+    "import/extensions": ["error", "ignorePackages"],
     "import/order": [
       "error",
       {
@@ -47,11 +50,6 @@
     "import/external-module-folders": [".yarn"],
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx"]
-    },
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
-      }
     },
     "react": {
       "version": "detect"

--- a/.yarn/versions/f1252499.yml
+++ b/.yarn/versions/f1252499.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -6,7 +6,11 @@ import "prosemirror-view/style/prosemirror.css";
 import React, { useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import { NodeViewComponentProps, ProseMirror, useNodeViews } from "../src";
+import {
+  NodeViewComponentProps,
+  ProseMirror,
+  useNodeViews,
+} from "../src/index.js";
 
 import "./main.css";
 

--- a/src/components/__tests__/ProseMirror.test.tsx
+++ b/src/components/__tests__/ProseMirror.test.tsx
@@ -5,13 +5,13 @@ import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import React, { useEffect, useState } from "react";
 
-import { useNodeViews } from "../../hooks/useNodeViews";
-import { NodeViewComponentProps } from "../../nodeViews/createReactNodeViewConstructor";
+import { useNodeViews } from "../../hooks/useNodeViews.js";
+import { NodeViewComponentProps } from "../../nodeViews/createReactNodeViewConstructor.js";
 import {
   setupProseMirrorView,
   teardownProseMirrorView,
-} from "../../testing/setupProseMirrorView";
-import { ProseMirror } from "../ProseMirror";
+} from "../../testing/setupProseMirrorView.js";
+import { ProseMirror } from "../ProseMirror.js";
 
 describe("ProseMirror", () => {
   beforeAll(() => {

--- a/src/contexts/EditorContext.ts
+++ b/src/contexts/EditorContext.ts
@@ -2,7 +2,7 @@ import type { EditorState } from "prosemirror-state";
 import type { DOMEventMap, EditorView } from "prosemirror-view";
 import { createContext } from "react";
 
-import type { EventHandler } from "../hooks/useComponentEventListenersPlugin";
+import type { EventHandler } from "../hooks/useComponentEventListenersPlugin.js";
 
 interface EditorContextValue {
   editorView: EditorView | null;

--- a/src/hooks/useComponentEventListenersPlugin.tsx
+++ b/src/hooks/useComponentEventListenersPlugin.tsx
@@ -24,7 +24,6 @@ function createComponentEventListenersPlugin(
         batch(() => {
           handled = !!handler.call(this, view, event);
         });
-        console.log(handled);
         if (handled || event.defaultPrevented) return true;
       }
       return false;

--- a/src/hooks/useEditorEventListener.ts
+++ b/src/hooks/useEditorEventListener.ts
@@ -4,7 +4,7 @@ import { useCallback, useContext, useRef } from "react";
 
 import { EditorContext } from "../contexts/EditorContext.js";
 
-import type { EventHandler } from "./useComponentEventListenersPlugin";
+import type { EventHandler } from "./useComponentEventListenersPlugin.js";
 import { useEditorEffect } from "./useEditorEffect.js";
 
 /**
@@ -37,5 +37,5 @@ export function useEditorEventListener<EventType extends keyof DOMEventMap>(
   useEditorEffect(() => {
     registerEventListener(eventType, eventHandler);
     return () => unregisterEventListener(eventType, eventHandler);
-  }, [registerEventListener, unregisterEventListener]);
+  }, [eventHandler, eventType, registerEventListener, unregisterEventListener]);
 }

--- a/src/hooks/useNodeViewPortals.ts
+++ b/src/hooks/useNodeViewPortals.ts
@@ -1,7 +1,7 @@
 import { ReactPortal, useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { RegisterElement } from "../nodeViews/createReactNodeViewConstructor";
+import { RegisterElement } from "../nodeViews/createReactNodeViewConstructor.js";
 
 /**
  * Provides an array of React portals and a callback for registering

--- a/src/hooks/useNodeViews.ts
+++ b/src/hooks/useNodeViews.ts
@@ -3,9 +3,9 @@ import { useMemo } from "react";
 import {
   ReactNodeViewConstructor,
   createReactNodeViewConstructor,
-} from "../nodeViews/createReactNodeViewConstructor";
+} from "../nodeViews/createReactNodeViewConstructor.js";
 
-import { useNodeViewPortals } from "./useNodeViewPortals";
+import { useNodeViewPortals } from "./useNodeViewPortals.js";
 
 export function useNodeViews(
   nodeViews: Record<string, ReactNodeViewConstructor>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export { useEditorView } from "./hooks/useEditorView.js";
 export { useNodeViews } from "./hooks/useNodeViews.js";
 export { useComponentEventListenersPlugin } from "./hooks/useComponentEventListenersPlugin.js";
 
-export type { NodeViewComponentProps } from "./nodeViews/createReactNodeViewConstructor";
+export type { NodeViewComponentProps } from "./nodeViews/createReactNodeViewConstructor.js";


### PR DESCRIPTION
This adds ESLint rules to ban `console.log` statements and require file extensions, since we're dual-building and ESM requires file extensions!