### PR TITLE
Pass node view constructor arguments through to react node view constructors

### DIFF
--- a/.yarn/versions/9229b989.yml
+++ b/.yarn/versions/9229b989.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ augmenting NodeView constructors with React components.
 
 `useNodeViews` takes a map from node name to an extended NodeView constructor.
 The NodeView constructor must return at least a `dom` attribute and a
-`component` attribute, but can also return any other NodeView attributes, aside
-from the `update` method. Here's an example of its usage:
+`component` attribute, but can also return any other NodeView attributes. Here's
+an example of its usage:
 
 ```tsx
 import {
@@ -577,23 +577,32 @@ export function SelectionWidget() {
  * Extension of ProseMirror's NodeViewConstructor type to include
  * `component`, the React component to used render the NodeView.
  * All properties other than `component` and `dom` are optional.
- *
- * Unlike ProseMirror's NodeViewConstructor, this function will
- * not be passed any arguments. Instead, `node`, `getPos`, and
- * `decorations` will be passed as props to the React component,
- * and `view` should only be accessed via the above React hooks.
  */
-type ReactNodeViewConstructor = () => {
+type ReactNodeViewConstructor = (
+  node: Node,
+  view: EditorView,
+  getPos: () => number,
+  decorations: readonly Decoration[],
+  innerDecorations: DecorationSource
+) => {
   dom: HTMLElement | null;
   component: React.ComponentType<NodeViewComponentProps>;
   contentDOM?: HTMLElement | null;
   selectNode?: () => void;
   deselectNode?: () => void;
-  setSelection?:
-    | (anchor: number, head: number, root: Document | ShadowRoot) => void;
+  setSelection?: (
+    anchor: number,
+    head: number,
+    root: Document | ShadowRoot
+  ) => void;
   stopEvent?: (event: Event) => boolean;
   ignoreMutation?: (mutation: MutationRecord) => boolean;
   destroy?: () => void;
+  update?: (
+    node: Node,
+    decorations: readonly Decoration[],
+    innerDecoration: DecorationSource
+  ) => boolean;
 };
 
 type useNodeViews = (nodeViews: Record<string, ReactNodeViewConstructor>) => {

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -11,6 +11,7 @@ import {
   ProseMirror,
   useNodeViews,
 } from "../src/index.js";
+import { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
 
 import "./main.css";
 
@@ -21,6 +22,7 @@ const schema = new Schema({
     text: { group: "inline" },
   },
 });
+
 const editorState = EditorState.create({
   schema,
   plugins: [keymap(baseKeymap)],
@@ -30,7 +32,7 @@ function Paragraph({ children }: NodeViewComponentProps) {
   return <p>{children}</p>;
 }
 
-const reactNodeViews = {
+const reactNodeViews: Record<string, ReactNodeViewConstructor> = {
   paragraph: () => ({
     component: Paragraph,
     dom: document.createElement("div"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,8 @@ export { useEditorView } from "./hooks/useEditorView.js";
 export { useNodeViews } from "./hooks/useNodeViews.js";
 export { useComponentEventListenersPlugin } from "./hooks/useComponentEventListenersPlugin.js";
 
-export type { NodeViewComponentProps } from "./nodeViews/createReactNodeViewConstructor.js";
+export type {
+  NodeViewComponentProps,
+  ReactNodeView,
+  ReactNodeViewConstructor,
+} from "./nodeViews/createReactNodeViewConstructor.js";


### PR DESCRIPTION
We want to enable consumers to:

1. Make decisions about their `dom` and `contentDOM` elements based on their node and decorations
2. Implement a custom `update` to tell ProseMirror to re-build a node view (and its `dom` and contentDOM`) when attributes that it cares about change