### PR TITLE
RFC: Hide node view wrappers from CSSOM with display: contents

### DIFF
--- a/.yarn/versions/c193871f.yml
+++ b/.yarn/versions/c193871f.yml
@@ -1,2 +1,2 @@
 releases:
-  "@nytimes/react-prosemirror": patch
+  "@nytimes/react-prosemirror": minor

--- a/demo/main.css
+++ b/demo/main.css
@@ -11,3 +11,8 @@ main {
   width: 80%;
   max-width: 700px;
 }
+
+ul li {
+  display: flex;
+  flex-direction: row;
+}

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -3,7 +3,7 @@ import { keymap } from "prosemirror-keymap";
 import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import "prosemirror-view/style/prosemirror.css";
-import React, { useState } from "react";
+import React, { ComponentType, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import {
@@ -11,13 +11,14 @@ import {
   ProseMirror,
   useNodeViews,
 } from "../src/index.js";
-import { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
 
 import "./main.css";
 
 const schema = new Schema({
   nodes: {
     doc: { content: "block+" },
+    list: { group: "block", content: "list_item+" },
+    list_item: { content: "paragraph+" },
     paragraph: { group: "block", content: "inline*" },
     text: { group: "inline" },
   },
@@ -32,12 +33,18 @@ function Paragraph({ children }: NodeViewComponentProps) {
   return <p>{children}</p>;
 }
 
-const reactNodeViews: Record<string, ReactNodeViewConstructor> = {
-  paragraph: () => ({
-    component: Paragraph,
-    dom: document.createElement("div"),
-    contentDOM: document.createElement("span"),
-  }),
+function List({ children }: NodeViewComponentProps) {
+  return <ul>{children}</ul>;
+}
+
+function ListItem({ children }: NodeViewComponentProps) {
+  return <li>{children}</li>;
+}
+
+const reactNodeViews: Record<string, ComponentType<NodeViewComponentProps>> = {
+  paragraph: Paragraph,
+  list: List,
+  list_item: ListItem,
 };
 
 function DemoEditor() {

--- a/src/components/__tests__/ProseMirror.test.tsx
+++ b/src/components/__tests__/ProseMirror.test.tsx
@@ -97,11 +97,7 @@ describe("ProseMirror", () => {
     }
 
     const reactNodeViews = {
-      paragraph: () => ({
-        component: Paragraph,
-        dom: document.createElement("div"),
-        contentDOM: document.createElement("span"),
-      }),
+      paragraph: Paragraph,
     };
 
     function TestEditor() {

--- a/src/hooks/useNodeViews.ts
+++ b/src/hooks/useNodeViews.ts
@@ -1,14 +1,14 @@
-import { useMemo } from "react";
+import { ComponentType, useMemo } from "react";
 
 import {
-  ReactNodeViewConstructor,
+  NodeViewComponentProps,
   createReactNodeViewConstructor,
 } from "../nodeViews/createReactNodeViewConstructor.js";
 
 import { useNodeViewPortals } from "./useNodeViewPortals.js";
 
 export function useNodeViews(
-  nodeViews: Record<string, ReactNodeViewConstructor>
+  nodeViews: Record<string, ComponentType<NodeViewComponentProps>>
 ) {
   const { registerPortal, portals } = useNodeViewPortals();
 


### PR DESCRIPTION
A pain point with the current React Node View implementation is that components are "wrapped" with several layers of DOM that exist solely for the purpose of providing ProseMirror with "handles" synchronously in node view constructors. Each node view component ends up wrapped with one element (the node view `dom`), and its children are wrapped with _two_ elements (the node view `contentDOM`, _and_ the wrapper that we render in React so that we know where to put the `contentDOM` node).

Because these nodes affect content models and styling, it was important to expose them to users. However, this PR removes that configuration point, instead leaving users with a simple API that only requires a component. Under the hood, we _always_ create a `div` or `span` (details below) for the `dom` (and `contentDOM`/`contentDOM` wrapper for non-leaf nodes), and we always set the `display` style to `contents`. This means that the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) treats the wrappers as if the weren't there (more or less), allowing users to essentially ignore them.

One note of significance is that this can still produce invalid _DOM_, even if the resulting CSSOM (after the `display: contents` has been applied) is valid. To attempt to mitigate this, we use `span`s in places where we expect elements to be used inline:

1. If `node.isInline`, its `dom` will be a `span`
2. If `node.textBlock`, its `contentDOMWrapper` and `contentDOM` will be `span`s

Another important consideration is that there are still some cases where users have to be aware of these wrappers to some extent. Specifically, this change enables writing CSS like this:

```css
ul li {
  display: flex;
}
```

because flexbox will ignore the `display: contents` contentDOMWrapper and contentDOM elements. On the other hand, this CSS will not work:

```css
ul > li {
  color: blue;
}
```

because query selectors still operate on the DOM, and don't ignore `display: contents` elements.