### PR TITLE
Replace getPos with useNodePos

### DIFF
--- a/.yarn/versions/bf34ddf6.yml
+++ b/.yarn/versions/bf34ddf6.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": minor

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ yarn add @nytimes/react-prosemirror
   - [`useEditorEventCallback`](#useeditoreventcallback-1)
   - [`useEditorEventListener`](#useeditoreventlistener-1)
   - [`useEditorEffect`](#useeditoreffect-1)
+  - [`useNodePos`](#usenodepos)
   - [`useNodeViews`](#usenodeviews)
 
 <!-- tocstop -->
@@ -277,12 +278,13 @@ You can use this hook to implement custom behavior in your NodeViews:
 ```tsx
 import { useEditorEventListener } from "@nytimes/react-prosemirror";
 
-function Paragraph({ node, getPos, children }) {
+function Paragraph({ node, children }) {
+  const nodeStart = useNodePos();
+
   useEditorEventListener("keydown", (view, event) => {
     if (event.code !== "ArrowDown") {
       return false;
     }
-    const nodeStart = getPos();
     const nodeEnd = nodeStart + node.nodeSize;
     const { selection } = view.state;
     if (selection.anchor < nodeStart || selection.anchor > nodeEnd) {
@@ -569,6 +571,19 @@ export function SelectionWidget() {
   )
 }
 ```
+
+### `useNodePos`
+
+```tsx
+type useNodePos = () => number;
+```
+
+Returns the node's current position in the document. Takes the place of
+ProseMirror's `getPos` function that gets passed to NodeView's, which is unsafe
+to use in React render functions.
+
+This hook can only be used in React components rendered with
+[`useNodeViews`](#usenodeviews).
 
 ### `useNodeViews`
 

--- a/src/hooks/useNodePos.tsx
+++ b/src/hooks/useNodePos.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode, createContext, useContext } from "react";
+
+import { NodeKey, reactPluginKey } from "../plugins/react.js";
+
+import { useEditorState } from "./useEditorState.js";
+
+type Props = {
+  key: NodeKey;
+  children: ReactNode;
+};
+
+const NodePosContext = createContext<number>(null as unknown as number);
+
+export function NodePosProvider({ key, children }: Props) {
+  const editorState = useEditorState();
+  if (!editorState) return <>{children}</>;
+  const pluginState = reactPluginKey.getState(editorState);
+  return (
+    <NodePosContext.Provider value={pluginState?.keyToPos.get(key) ?? 0}>
+      {children}
+    </NodePosContext.Provider>
+  );
+}
+
+export function useNodePos() {
+  return useContext(NodePosContext);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { useEditorEventListener } from "./hooks/useEditorEventListener.js";
 export { useEditorState } from "./hooks/useEditorState.js";
 export { useEditorView } from "./hooks/useEditorView.js";
 export { useNodeViews } from "./hooks/useNodeViews.js";
+export { useNodePos } from "./hooks/useNodePos.js";
 
 export type {
   NodeViewComponentProps,


### PR DESCRIPTION
The `getPos` function passed to Node Views from ProseMirror is unsafe to use in the render function of React Components, because its return value is derived from the state of the EditorView.

Instead, since #27 implements a plugin tracking the position of each node, this PR exposes a `useNodePos` hook that, under the hood, retrieves the current position of the node in the editorState via that node's key.