### PR TITLE
Preserve event listener ordering

### DIFF
--- a/.yarn/versions/d438c5f0.yml
+++ b/.yarn/versions/d438c5f0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/hooks/useComponentEventListeners.tsx
+++ b/src/hooks/useComponentEventListeners.tsx
@@ -34,13 +34,13 @@ import {
  */
 export function useComponentEventListeners() {
   const [registry, setRegistry] = useState(
-    new Map<keyof DOMEventMap, Set<EventHandler>>()
+    new Map<keyof DOMEventMap, Array<EventHandler>>()
   );
 
   const registerEventListener = useCallback(
     (eventType: keyof DOMEventMap, handler: EventHandler) => {
-      const handlers = registry.get(eventType) ?? new Set<EventHandler>();
-      handlers.add(handler);
+      const handlers = registry.get(eventType) ?? [];
+      handlers.unshift(handler);
       if (!registry.has(eventType)) {
         registry.set(eventType, handlers);
         setRegistry(new Map(registry));
@@ -52,7 +52,7 @@ export function useComponentEventListeners() {
   const unregisterEventListener = useCallback(
     (eventType: keyof DOMEventMap, handler: EventHandler) => {
       const handlers = registry.get(eventType);
-      handlers?.delete(handler);
+      handlers?.splice(handlers.indexOf(handler), 1);
     },
     [registry]
   );

--- a/src/plugins/componentEventListeners.ts
+++ b/src/plugins/componentEventListeners.ts
@@ -11,7 +11,7 @@ export type EventHandler<
 ) => boolean | void;
 
 export function componentEventListeners(
-  eventHandlerRegistry: Map<keyof DOMEventMap, Set<EventHandler>>
+  eventHandlerRegistry: Map<keyof DOMEventMap, Iterable<EventHandler>>
 ) {
   const domEventHandlers: Record<keyof DOMEventMap, EventHandler> = {};
 


### PR DESCRIPTION
As this hook is currently written, event handlers are registered (and therefore executed) "top-down". That is, a parent component's event handler will be executed before its child components'. This makes it impossible for child components to override or intercept events that are handled by their parents!

This PR simply reverses the order in which handlers are registered (newer handlers, registered further down the component tree, are registered first, rather than last), so that the plugin executes them "bottom-up", which matches the expected behavior for event handlers in React/the DOM generally.