### PR TITLE
Add support for uncontrolled ProseMirror component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "node": false
   },
   "rules": {
-    "no-console": ["off", { "allow": "error" }],
+    "no-console": ["error", { "allow": ["error"] }],
     "react-hooks/exhaustive-deps": [
       "warn",
       {

--- a/.yarn/versions/27cac6b1.yml
+++ b/.yarn/versions/27cac6b1.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export function ProseMirrorEditor() {
   const [mount, setMount] = useState();
 
   return (
-    <ProseMirror mount={mount} state={EditorState.create({ schema })}>
+    <ProseMirror mount={mount} defaultState={EditorState.create({ schema })}>
       <div ref={setMount} />
     </ProseMirror>
   );
@@ -368,7 +368,7 @@ function ProseMirrorEditor() {
   return (
     <ProseMirror
       mount={mount}
-      state={EditorState.create({ schema })}
+      defaultState={EditorState.create({ schema })}
       nodeViews={nodeViews}
     >
       <div ref={setMount} />
@@ -383,13 +383,13 @@ function ProseMirrorEditor() {
 ### `ProseMirror`
 
 ```tsx
-type ProseMirror = (props: {
-  dispatchTransaction: (tr: Transaction) => void;
-  editorProps: EditorProps;
-  editorState: EditorState;
-  mount: HTMLElement | null;
-  children?: ReactNode | null;
-}) => JSX.Element;
+type ProseMirror = (
+  props: {
+    mount: HTMLElement;
+    children: ReactNode;
+  } & DirectEditorProps &
+    ({ defaultState: EditorState } | { state: EditorState })
+) => JSX.Element;
 ```
 
 Renders the ProseMirror View onto a DOM mount.

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -9,6 +9,8 @@ import { createRoot } from "react-dom/client";
 import {
   NodeViewComponentProps,
   ProseMirror,
+  useEditorEffect,
+  useEditorState,
   useNodeViews,
 } from "../src/index.js";
 import { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
@@ -47,7 +49,11 @@ function DemoEditor() {
   return (
     <main>
       <h1>React ProseMirror Demo</h1>
-      <ProseMirror mount={mount} state={editorState} nodeViews={nodeViews}>
+      <ProseMirror
+        mount={mount}
+        defaultState={editorState}
+        nodeViews={nodeViews}
+      >
         <div ref={setMount} />
         {renderNodeViews()}
       </ProseMirror>

--- a/src/components/ProseMirrorInner.tsx
+++ b/src/components/ProseMirrorInner.tsx
@@ -1,12 +1,11 @@
-import type { DirectEditorProps } from "prosemirror-view";
 import React, { useMemo } from "react";
 import type { ReactNode } from "react";
 
 import { EditorProvider } from "../contexts/EditorContext.js";
 import { useComponentEventListeners } from "../hooks/useComponentEventListeners.js";
-import { useEditorView } from "../hooks/useEditorView.js";
+import { EditorProps, useEditorView } from "../hooks/useEditorView.js";
 
-export type ProseMirrorProps = DirectEditorProps & {
+export type ProseMirrorProps = EditorProps & {
   mount: HTMLElement | null;
   children?: ReactNode | null;
 };
@@ -35,7 +34,6 @@ export type ProseMirrorProps = DirectEditorProps & {
 export function ProseMirrorInner({
   children,
   dispatchTransaction,
-  state,
   mount,
   ...editorProps
 }: ProseMirrorProps) {
@@ -53,18 +51,20 @@ export function ProseMirrorInner({
   const editorView = useEditorView(mount, {
     ...editorProps,
     plugins,
-    state,
     dispatchTransaction,
   });
+
+  const editorState =
+    "state" in editorProps ? editorProps.state : editorView?.state ?? null;
 
   const editorContextValue = useMemo(
     () => ({
       editorView,
-      editorState: state,
+      editorState,
       registerEventListener,
       unregisterEventListener,
     }),
-    [editorView, state, registerEventListener, unregisterEventListener]
+    [editorState, editorView, registerEventListener, unregisterEventListener]
   );
 
   return (


### PR DESCRIPTION
Adds a `defaultState` prop to support uncontrolled usage of the ProseMirror component! This PR ensures that `useEditorState` always returns an up-to-date EditorState, whether that's from the state prop or from the view state (if uncontrolled)