### PR TITLE
Add SMores as a CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nytimes/react-prosemirror-maintainers
+* @nytimes/react-prosemirror-maintainers @SMores


### PR DESCRIPTION
It would be cool/convenient/useful if I could approve and merge PRs (like dependabot bumps, e.g.)!