### PR TITLE
Modify useEditorView to flushSync all dispatched transactions

### DIFF
--- a/.yarn/versions/290b480a.yml
+++ b/.yarn/versions/290b480a.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/.yarn/versions/290b480a.yml
+++ b/.yarn/versions/290b480a.yml
@@ -1,2 +1,2 @@
 releases:
-  "@nytimes/react-prosemirror": patch
+  "@nytimes/react-prosemirror": minor

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+nodeLinker: pnp
+
 changesetIgnorePatterns:
   - "**/*.{test}.{js,ts,jsx,tsx}"
   - "!(.yarn/versions/**|src/**/*|package.json|.swcrc*)"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
-nodeLinker: pnp
-
 changesetIgnorePatterns:
   - "**/*.{test}.{js,ts,jsx,tsx}"
   - "!(.yarn/versions/**|src/**/*|package.json|.swcrc*)"

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -1,10 +1,10 @@
-import { useForceUpdate } from "./useForceUpdate.js";
-
 import type { EditorState, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import type { DirectEditorProps } from "prosemirror-view";
 import { useLayoutEffect, useState } from "react";
 import { flushSync } from "react-dom";
+
+import { useForceUpdate } from "./useForceUpdate.js";
 
 /**
  *

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -117,12 +117,12 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   }, [editorProps, mount, state, view]);
 
   useLayoutEffect(() => {
-    view?.setProps(nonStateProps);
-  }, [view, nonStateProps]);
-
-  useLayoutEffect(() => {
     if (stateProp) view?.setProps({ state: stateProp });
   }, [view, stateProp]);
+
+  useLayoutEffect(() => {
+    view?.setProps(nonStateProps);
+  }, [view, nonStateProps]);
 
   return view;
 }

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -117,12 +117,12 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   }, [editorProps, mount, state, view]);
 
   useLayoutEffect(() => {
-    if (stateProp) view?.setProps({ state: stateProp });
-  }, [view, stateProp]);
-
-  useLayoutEffect(() => {
     view?.setProps(nonStateProps);
   }, [view, nonStateProps]);
+
+  useLayoutEffect(() => {
+    if (stateProp) view?.setProps({ state: stateProp });
+  }, [view, stateProp]);
 
   return view;
 }

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -6,6 +6,20 @@ import type { DirectEditorProps } from "prosemirror-view";
 import { useLayoutEffect, useRef, useState } from "react";
 import { unstable_batchedUpdates as batch } from "react-dom";
 
+/**
+ *
+ * The view.composing state is when the compositionStart eventListener activates,
+ * which creates an input method editor (IME) for foreign languages.
+ * https://prosemirror.net/docs/ref/#view.EditorView.composing
+ *
+ * In rare exceptions, we want to dispatch transactions in non-batched form
+ * when the editorView is in a composing state to maintain DOM parity.
+ *
+ * See React 18's documentation on opting out of automatic batching
+ * https://react.dev/blog/2022/03/08/react-18-upgrade-guide#automatic-batching
+ *
+ * Returns a conditionally modified props.dispatchTransaction function
+ */
 function withConditionalFlushUpdates<This, T extends unknown[]>(
   fn: (this: This, ...args: T) => void,
   view: EditorView | null
@@ -36,16 +50,9 @@ type EditorStateProps =
 export type EditorProps = Omit<DirectEditorProps, "state"> & EditorStateProps;
 
 /**
- * Enhances editor props so transactions dispatch in a batched update.
+ * Conditionally modifies dispatchTransaction props
  *
- * It is important that changes to the editor get batched by React so that any
- * components that dispatch transactions in effects do so after rendering with
- * state changes from any previous transaction, so that they may use the latest
- * state and not trigger nested transactions.
- *
- * TODO(OK-4006): We can remove this helper and pass the direct editor props to
- * the Editor View unmodified after we upgrade to React 18, which batches every
- * update by default.
+ * Returns modified DirectEditorProps
  */
 function withConditionalFlushDispatch(
   props: EditorProps,

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -107,6 +107,14 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   );
 
   useLayoutEffect(() => {
+    editorPropsRef.current = withConditionalFlushDispatch(
+      props,
+      forceUpdate,
+      view
+    );
+  }, [props, view, forceUpdate]);
+
+  useLayoutEffect(() => {
     return () => {
       if (view) {
         view.destroy();
@@ -145,14 +153,6 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   useLayoutEffect(() => {
     if (stateProp) view?.setProps({ state: stateProp });
   }, [view, stateProp]);
-
-  useLayoutEffect(() => {
-    editorPropsRef.current = withConditionalFlushDispatch(
-      props,
-      forceUpdate,
-      view
-    );
-  }, [props, view, forceUpdate]);
 
   return view;
 }

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -6,20 +6,6 @@ import { flushSync } from "react-dom";
 
 import { useForceUpdate } from "./useForceUpdate.js";
 
-/**
- *
- * The view.composing state is when the compositionStart eventListener activates,
- * which creates an input method editor (IME) for foreign languages.
- * https://prosemirror.net/docs/ref/#view.EditorView.composing
- *
- * In rare exceptions, we want to dispatch transactions in non-batched form
- * when the editorView is in a composing state to maintain DOM parity.
- *
- * See React 18's documentation on opting out of automatic batching
- * https://react.dev/blog/2022/03/08/react-18-upgrade-guide#automatic-batching
- *
- * Returns a conditionally modified props.dispatchTransaction function
- */
 function withFlushedUpdates<This, T extends unknown[]>(
   fn: (this: This, ...args: T) => void
 ): (...args: T) => void {
@@ -44,11 +30,6 @@ type EditorStateProps =
 
 export type EditorProps = Omit<DirectEditorProps, "state"> & EditorStateProps;
 
-/**
- * Conditionally modifies dispatchTransaction props
- *
- * Returns modified DirectEditorProps
- */
 function withFlushedDispatch(
   props: EditorProps,
   forceUpdate: () => void

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -1,10 +1,10 @@
+import { useForceUpdate } from "./useForceUpdate.js";
+
 import type { EditorState, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import type { DirectEditorProps } from "prosemirror-view";
 import { useLayoutEffect, useRef, useState } from "react";
 import { unstable_batchedUpdates as batch } from "react-dom";
-
-import { useForceUpdate } from "./useForceUpdate.js";
 
 function withConditionalFlushUpdates<This, T extends unknown[]>(
   fn: (this: This, ...args: T) => void,
@@ -152,7 +152,7 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
       forceUpdate,
       view
     );
-  }, [props, view]);
+  }, [props, view, forceUpdate]);
 
   return view;
 }


### PR DESCRIPTION
This change ensures a flushSync-only behavior when dispatching transactions. [Because react 18 automatically batches state updates](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#automatic-batching), we can also remove references in the code where we used unstable_batchedUpdates in general.