### PR TITLE
Adds a new job for running unit tests in GH Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,3 +32,21 @@ jobs:
         run:
           git fetch origin main --depth 1 && ./scripts/if-no-version-change.sh
           yarn version check
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Test
+        run: yarn test

--- a/.yarn/versions/d8b49192.yml
+++ b/.yarn/versions/d8b49192.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -59,7 +59,7 @@ function withBatchedDispatch(
           props.dispatchTransaction ?? defaultDispatchTransaction
         );
         batchedDispatchTransaction.call(this, tr);
-        forceUpdate();
+        if (!("state" in props)) forceUpdate();
       },
     },
   };


### PR DESCRIPTION
We weren't actually running our unit tests on PRs! Whoops! This adds a new GH Actions job that just runs our unit tests. It's in a separate job so that we can see test results regardless of other static analysis checks succeed or fail.

In addition:

When we added support for uncontrolled state (#34), we added an unconditional `forceUpdate` call in `dispatchTransaction` that was basically impossible to wrap in an `act` call in tests. This means that our tests were complaining about state updates that weren't wrapped in `act` (though they were all performing correctly, because they were all using controlled state).

This wasn't strictly necessary; the `forceUpdate` call is only needed when state is uncontrolled, so we don't have to run it when a `state` prop is passed, which all of our tests do. To quiet the test logs, this PR makes the `forceUpdate` call conditional on the absence of a `state` prop.