### PR TITLE
fix: ordering of layout effect not running properly on compose events

### DIFF
--- a/.yarn/versions/157dd0b7.yml
+++ b/.yarn/versions/157dd0b7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -130,12 +130,12 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   }, [editorProps, mount, state, view]);
 
   useLayoutEffect(() => {
-    view?.setProps(nonStateProps);
-  }, [view, nonStateProps]);
-
-  useLayoutEffect(() => {
     if (stateProp) view?.setProps({ state: stateProp });
   }, [view, stateProp]);
+
+  useLayoutEffect(() => {
+    view?.setProps(nonStateProps);
+  }, [view, nonStateProps]);
 
   return view;
 }


### PR DESCRIPTION
After switching to flush-sync, compose events were still not working immediately, this is due to the ordering of the useLayoutEffect for the state prop. Prop state should be set first before non-state props. 