### PR TITLE
fixes errors thrown when React unmounts the contentDOMWrapper

### DIFF
--- a/.yarn/versions/ff007ec7.yml
+++ b/.yarn/versions/ff007ec7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -174,7 +174,9 @@ export function createReactNodeViewConstructor(
                   // parent so that later we can reassemble the DOM hierarchy
                   // React expects when cleaning up the ContentDOMWrapper element
                   if (nextContentDOMWrapper?.parentNode) {
-                    setContentDOMParent(nextContentDOMWrapper.parentNode as HTMLElement);                    
+                    setContentDOMParent(
+                      nextContentDOMWrapper.parentNode as HTMLElement
+                    );
                   }
                 }}
               />

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -270,7 +270,7 @@ export function createReactNodeViewConstructor(
         // from the DOM. Here we attempt to reassemble the DOM that React
         // expects when cleaning up the portal.
         if (componentRef?.contentDOMParent) {
-          this.dom.appendChild(componentRef?.contentDOMParent);
+          this.dom.appendChild(componentRef.contentDOMParent);
         }
         unregisterElement();
         reactNodeView.destroy?.();

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -41,6 +41,7 @@ interface NodeViewWrapperProps {
 interface NodeViewWrapperRef {
   node: Node;
   contentDOMWrapper: HTMLElement | null;
+  contentDOMParent: HTMLElement | null;
   setNode: Dispatch<SetStateAction<Node>>;
   setDecorations: Dispatch<SetStateAction<readonly Decoration[]>>;
   setIsSelected: Dispatch<SetStateAction<boolean>>;
@@ -142,18 +143,21 @@ export function createReactNodeViewConstructor(
       const [contentDOMWrapper, setContentDOMWrapper] =
         useState<HTMLElement | null>(null);
 
+      const [contentDOMParent, setContentDOMParent] =
+        useState<HTMLElement | null>(null);
+
       useImperativeHandle(
         ref,
         () => ({
           node,
           contentDOMWrapper: contentDOMWrapper,
+          contentDOMParent: contentDOMParent,
           setNode,
           setDecorations,
           setIsSelected,
         }),
-        [node, contentDOMWrapper]
+        [node, contentDOMWrapper, contentDOMParent]
       );
-
       return (
         <NodePosProvider key={nodeKey}>
           <ReactComponent
@@ -166,6 +170,12 @@ export function createReactNodeViewConstructor(
                 style={{ display: "contents" }}
                 ref={(nextContentDOMWrapper) => {
                   setContentDOMWrapper(nextContentDOMWrapper);
+                  // we preserve a reference to the contentDOMWrapper'
+                  // parent so that later we can reassemble the DOM hierarchy
+                  // React expects when cleaning up the ContentDOMWrapper element
+                  if (nextContentDOMWrapper?.parentNode) {
+                    setContentDOMParent(nextContentDOMWrapper.parentNode as HTMLElement);                    
+                  }
                 }}
               />
             )}
@@ -252,6 +262,14 @@ export function createReactNodeViewConstructor(
         return false;
       },
       destroy() {
+        // React expects the contentDOMParent to be a child of the
+        // DOM element where the portal was mounted, but in some situations
+        // contenteditable may have already detached the contentDOMParent
+        // from the DOM. Here we attempt to reassemble the DOM that React
+        // expects when cleaning up the portal.
+        if (componentRef?.contentDOMParent) {
+          this.dom.appendChild(componentRef?.contentDOMParent);
+        }
         unregisterElement();
         reactNodeView.destroy?.();
       },


### PR DESCRIPTION
This PR proposes a fix to #42 within the current architecture (where we create wrapping nodes and React portals for node views).

The inspiration for this approach comes from a previous implementation where we had to do something like what happens on this branch: at the moment that a NodeView's `destroy` hook is being called, we re-attach the parts of the DOM which React controls in roughly the locations where React expects them for its cleanup phase.