### PR TITLE
NodePosProvider key -> nodeKey

### DIFF
--- a/.yarn/versions/5245b9ba.yml
+++ b/.yarn/versions/5245b9ba.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/hooks/useNodePos.tsx
+++ b/src/hooks/useNodePos.tsx
@@ -5,18 +5,18 @@ import { NodeKey, reactPluginKey } from "../plugins/react.js";
 import { useEditorState } from "./useEditorState.js";
 
 type Props = {
-  key: NodeKey;
+  nodeKey: NodeKey;
   children: ReactNode;
 };
 
 const NodePosContext = createContext<number>(null as unknown as number);
 
-export function NodePosProvider({ key, children }: Props) {
+export function NodePosProvider({ nodeKey, children }: Props) {
   const editorState = useEditorState();
   if (!editorState) return <>{children}</>;
   const pluginState = reactPluginKey.getState(editorState);
   return (
-    <NodePosContext.Provider value={pluginState?.keyToPos.get(key) ?? 0}>
+    <NodePosContext.Provider value={pluginState?.keyToPos.get(nodeKey) ?? 0}>
       {children}
     </NodePosContext.Provider>
   );

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -159,7 +159,7 @@ export function createReactNodeViewConstructor(
         [node, contentDOMWrapper, contentDOMParent]
       );
       return (
-        <NodePosProvider key={nodeKey}>
+        <NodePosProvider nodeKey={nodeKey}>
           <ReactComponent
             node={node}
             decorations={decorations}


### PR DESCRIPTION
When running the demo, I was getting this React warning:

<img width="829" alt="Screenshot 2023-11-14 at 10 54 14 AM" src="https://github.com/nytimes/react-prosemirror/assets/707098/b43cf7a3-daff-4c51-af44-4c616d4dd6bd">

This branch fixes it.