### PR TITLE
0.4.0

### DIFF
--- a/.yarn/versions/5245b9ba.yml
+++ b/.yarn/versions/5245b9ba.yml
@@ -1,2 +1,0 @@
-releases:
-  "@nytimes/react-prosemirror": patch

--- a/.yarn/versions/bf34ddf6.yml
+++ b/.yarn/versions/bf34ddf6.yml
@@ -1,2 +1,0 @@
-releases:
-  "@nytimes/react-prosemirror": minor

--- a/.yarn/versions/ff007ec7.yml
+++ b/.yarn/versions/ff007ec7.yml
@@ -1,2 +1,0 @@
-releases:
-  "@nytimes/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nytimes/react-prosemirror",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This tags a new version reflecting some of the latest commits on `main`. I'm...not 100% sure how to make sure that, when this merges, we get a new version in `npm`. It looks like we don't auto-publish to `npm` (which is fine) but I'll check in w/ other folks to try to get the process documented, if it's not already.