### PR TITLE
Fix logo on non-GitHub hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React ProseMirror
 
 <p align="center">
-  <img src="react-prosemirror-logo.png" alt="React ProseMirror Logo" width="120px" height="120px"/>
+  <img src="https://github.com/nytimes/react-prosemirror/raw/main/react-prosemirror-logo.png" alt="React ProseMirror Logo" width="120px" height="120px"/>
   <br>
   <em>A fully featured library for safely integrating ProseMirror and React.</em>
   <br>


### PR DESCRIPTION
Using a relative URL means that the logo doesn't show up on npm :P this just makes it an absolute URL so that it works no matter where the README is hosted