### PR TITLE
Map positions forward to maintain key stability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,10 @@
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript][typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,28 +7,16 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
   "eslint.nodePath": ".yarn/sdks",
-  "editor.formatOnSave": true,
   "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "source.fixAll": true
-    }
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "source.fixAll": true
-    }
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[javascript][typescript]": {
-    "editor.codeActionsOnSave": {
-      "source.fixAll": "explicit"
-    }
   }
 }

--- a/.yarn/versions/1f4b945b.yml
+++ b/.yarn/versions/1f4b945b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "prosemirror-model": "^1.18.3",
     "prosemirror-schema-list": "^1.2.2",
     "prosemirror-state": "^1.4.2",
+    "prosemirror-transform": "^1.8.0",
     "prosemirror-view": "^1.29.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/plugins/__tests__/react.test.ts
+++ b/src/plugins/__tests__/react.test.ts
@@ -46,8 +46,8 @@ describe("reactNodeViewPlugin", () => {
     );
     const nextPluginState = reactPluginKey.getState(nextEditorState)!;
 
-    expect(Array.from(initialPluginState.keyToPos.keys())).toEqual(
-      Array.from(nextPluginState.keyToPos.keys())
+    expect(Array.from(nextPluginState.keyToPos.keys())).toEqual(
+      Array.from(initialPluginState.keyToPos.keys())
     );
   });
 

--- a/src/plugins/__tests__/react.test.ts
+++ b/src/plugins/__tests__/react.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
+import { findWrapping } from "prosemirror-transform";
 
 import { react, reactPluginKey } from "../react.js";
 
@@ -9,7 +10,7 @@ const schema = new Schema({
     doc: { content: "block+" },
     paragraph: { group: "block", content: "inline*" },
     list: { group: "block", content: "list_item+" },
-    list_item: { content: "inline*" },
+    list_item: { content: "paragraph+" },
     text: { group: "inline" },
   },
 });
@@ -69,10 +70,78 @@ describe("reactNodeViewPlugin", () => {
     const nextPluginState = reactPluginKey.getState(nextEditorState)!;
 
     // Adds new keys for new nodes
-    expect(nextPluginState.keyToPos.size).toBe(5);
+    expect(nextPluginState.keyToPos.size).toBe(6);
     // Maintains keys for previous nodes that are still there
     Array.from(initialPluginState.keyToPos.keys()).forEach((key) => {
       expect(Array.from(nextPluginState.keyToPos.keys())).toContain(key);
     });
+  });
+
+  it("should maintain key stability when splitting a node", () => {
+    const initialEditorState = EditorState.create({
+      doc: schema.topNodeType.create(null, [
+        schema.nodes.list.create(null, [
+          schema.nodes.list_item.create(null, [
+            schema.nodes.paragraph.create(null, [schema.text("first")]),
+          ]),
+        ]),
+      ]),
+      plugins: [react()],
+    });
+
+    const initialPluginState = reactPluginKey.getState(initialEditorState)!;
+
+    const nextEditorState = initialEditorState.apply(
+      initialEditorState.tr.insert(
+        1,
+        schema.nodes.list_item.create(null, [
+          schema.nodes.paragraph.create(null, [schema.text("second")]),
+        ])!
+      )
+    );
+    const nextPluginState = reactPluginKey.getState(nextEditorState)!;
+
+    // The new list item was inserted before the original one,
+    // pushing it further into the document. The original list
+    // item should keep its original key, and the new list item
+    // should be assigned a new one
+    expect(nextPluginState.posToKey.get(11)).toBe(
+      initialPluginState.posToKey.get(1)
+    );
+    expect(nextPluginState.posToKey.get(1)).not.toBe(
+      initialPluginState.posToKey.get(1)
+    );
+  });
+
+  it("should maintain key stability when wrapping a node", () => {
+    const initialEditorState = EditorState.create({
+      doc: schema.topNodeType.create(null, [
+        schema.nodes.paragraph.create(null, [schema.text("content")]),
+      ]),
+      plugins: [react()],
+    });
+
+    const initialPluginState = reactPluginKey.getState(initialEditorState)!;
+    const start = 1;
+    const end = 9;
+    const tr = initialEditorState.tr.delete(start, end);
+    const $start = tr.doc.resolve(start);
+
+    const range = $start.blockRange()!;
+    const wrapping = range && findWrapping(range, schema.nodes.list, null)!;
+    tr.wrap(range, wrapping);
+    const nextEditorState = initialEditorState.apply(tr);
+    const nextPluginState = reactPluginKey.getState(nextEditorState)!;
+
+    // The new list and list item nodes were wrapped around the
+    // paragraph, pushing it further into the document. The paragraph
+    // should keep its original key, and the new nodes
+    // should be assigned a new one
+    expect(nextPluginState.posToKey.get(2)).toBe(
+      initialPluginState.posToKey.get(0)
+    );
+    expect(nextPluginState.posToKey.get(0)).not.toBe(
+      initialPluginState.posToKey.get(0)
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,6 +1251,7 @@ __metadata:
     prosemirror-model: ^1.18.3
     prosemirror-schema-list: ^1.2.2
     prosemirror-state: ^1.4.2
+    prosemirror-transform: ^1.8.0
     prosemirror-view: ^1.29.1
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -6988,6 +6989,15 @@ __metadata:
   dependencies:
     prosemirror-model: ^1.0.0
   checksum: 0b8ec0953e7cf942ba3253cf54dac0e5d93172e3906f0b13e4ab72cc446271ec7542afbeeac0f8b72adb092cc15047ee06a6d4ed17c8a471acff8d20ddd92193
+  languageName: node
+  linkType: hard
+
+"prosemirror-transform@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "prosemirror-transform@npm:1.8.0"
+  dependencies:
+    prosemirror-model: ^1.0.0
+  checksum: 6d16ca4f954ad7b040a4adbb5ddfa8c8ad14b0514f15e1ecfd5e32f08eb3f8696492975b9e599b4776e991ab76df114166dcf6ec7b966a67b02b2069a28415f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rather than attempting to map the new node positions backward to determine what the key used to be for that node, start with the previous positions and map them forward, taking care to skip any positions that are deleted by the transaction, and adding any new nodes that didn't exist in the old doc. This improves stability and correctness in more complex cases, such as splitting or wrapping nodes, and nested deletions.

Fixes #73.

This is the same change as #91, but for the old architecture!