### PR TITLE
feat(editor): add before and after slots to editor component

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ function ProseMirrorEditor() {
 ```tsx
 type ProseMirror = (
   props: {
-    mount: HTMLElement;
-    children: ReactNode;
+    slotBefore: ReactNode;
+    slotAfter: ReactNode;
   } & DirectEditorProps &
     ({ defaultState: EditorState } | { state: EditorState })
 ) => JSX.Element;

--- a/src/components/ProseMirror.tsx
+++ b/src/components/ProseMirror.tsx
@@ -67,15 +67,17 @@ export type EditorProps = Omit<
 
 export type Props = EditorProps & {
   className?: string;
-  children?: ReactNode;
+  slotBefore?: ReactNode;
+  slotAfter?: ReactNode;
   as?: ReactElement;
 };
 
 export function ProseMirror({
   className,
-  children,
   nodeViews = {},
   customNodeViews = {},
+  slotAfter,
+  slotBefore,
   as,
   ...props
 }: Props) {
@@ -157,6 +159,7 @@ export function ProseMirror({
           }}
         >
           <>
+            {slotBefore}
             <DocNodeView
               className={className}
               ref={setMount}
@@ -166,7 +169,7 @@ export function ProseMirror({
               as={as}
               viewDesc={docViewDescRef.current}
             />
-            {children}
+            {slotAfter}
           </>
         </NodeViewContext.Provider>
       </EditorContext.Provider>


### PR DESCRIPTION
While migrating our codebase to the newer ReactEditorView, I realized that there is no convenient way to add a editor toolbar above the rendered document. The children of the `ProseMirror` component get inserted after the actual editor view.

A simple fix could be to define slots, before and after the document. This might even be a clearer wording than `children` since nested components aren't inserted as actual children.

But open for other solutions / ideas :) 