### PR TITLE
Updates a block comment to use correct naming for the LayoutGroup provider

### DIFF
--- a/src/hooks/useEditorEventCallback.ts
+++ b/src/hooks/useEditorEventCallback.ts
@@ -14,7 +14,7 @@ import { useEditorEffect } from "./useEditorEffect.js";
  *
  * This hook is dependent on both the
  * `EditorViewContext.Provider` and the
- * `DeferredLayoutEffectProvider`. It can only be used in a
+ * `LayoutGroup` provider. It can only be used in a
  * component that is mounted as a child of both of these
  * providers.
  */


### PR DESCRIPTION
This comment must have accidentally been left behind when `DeferredLayoutEffectProvider` was renamed `LayoutGroup` in https://github.com/nytimes/react-prosemirror/pull/11. 