### PR TITLE
Menu demo

### DIFF
--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -1,7 +1,7 @@
-import React, { ReactNode } from "react";
+import { toggleMark } from "prosemirror-commands";
 import type { MarkType } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { toggleMark } from "prosemirror-commands";
+import React, { ReactNode } from "react";
 
 function isMarkActive(mark: MarkType, state: EditorState): boolean {
   if (!state.selection) return false;

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -21,7 +21,6 @@ export function Button(props: {
   title: string;
   onClick: () => void;
 }) {
-
   return (
     <button
       type="button"

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -1,6 +1,6 @@
 import { toggleMark } from "prosemirror-commands";
 import type { MarkType } from "prosemirror-model";
-import type { EditorState, Transaction } from "prosemirror-state";
+import type { EditorState } from "prosemirror-state";
 import React, { ReactNode } from "react";
 
 import { useEditorEventCallback, useEditorState } from "../src/index.js";

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -40,17 +40,15 @@ export function Button(props: {
 export default function Menu() {
   const state = useEditorState();
 
-  const { marks } = state.schema;
-
   const toggleBold = useEditorEventCallback((view) => {
     if (!view) return;
-    const toggleBoldMark = toggleMark(marks["bold"]);
+    const toggleBoldMark = toggleMark(view.state.schema.marks["bold"]);
     toggleBoldMark(view.state, view.dispatch, view);
   });
 
   const toggleItalic = useEditorEventCallback((view) => {
     if (!view) return;
-    const toggleBoldMark = toggleMark(marks["em"]);
+    const toggleBoldMark = toggleMark(view.state.schema.marks["em"]);
     toggleBoldMark(view.state, view.dispatch, view);
   });
 
@@ -59,7 +57,7 @@ export default function Menu() {
       <Button
         className="bold"
         title="Bold (⌘b)"
-        isActive={isMarkActive(marks["strong"], state)}
+        isActive={!!state && isMarkActive(state.schema.marks["strong"], state)}
         onClick={toggleBold}
       >
         B
@@ -67,7 +65,7 @@ export default function Menu() {
       <Button
         className="italic"
         title="Italic (⌘i)"
-        isActive={isMarkActive(marks["em"], state)}
+        isActive={!!state && isMarkActive(state.schema.marks["em"], state)}
         onClick={toggleItalic}
       >
         I

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -42,7 +42,7 @@ export default function Menu() {
 
   const toggleBold = useEditorEventCallback((view) => {
     if (!view) return;
-    const toggleBoldMark = toggleMark(view.state.schema.marks["bold"]);
+    const toggleBoldMark = toggleMark(view.state.schema.marks["strong"]);
     toggleBoldMark(view.state, view.dispatch, view);
   });
 

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -1,0 +1,61 @@
+import React, { ReactNode } from "react";
+import type { MarkType } from "prosemirror-model";
+import type { EditorState, Transaction } from "prosemirror-state";
+import { toggleMark } from "prosemirror-commands";
+
+function isMarkActive(mark: MarkType, state: EditorState): boolean {
+  if (!state.selection) return false;
+  const { from, $from, to, empty } = state.selection;
+  return empty
+    ? !!mark.isInSet(state.storedMarks || $from.marks())
+    : state.doc.rangeHasMark(from, to, mark);
+}
+
+export function Button(props: {
+  children?: ReactNode;
+  isActive: boolean;
+  className?: string;
+  onClick: () => void;
+}) {
+  function handleMouseDown(e: React.MouseEvent) {
+    e.preventDefault();
+    props.onClick();
+  }
+  return (
+    <button
+      className={`button ${props.className} ${props.isActive ? "active" : ""}`}
+      onMouseDown={handleMouseDown}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+export default function Menu(props: {
+  state: EditorState;
+  dispatchTransaction: (transaction: Transaction) => void;
+}) {
+  const { marks } = props.state.schema;
+  return (
+    <div className="menu">
+      <Button
+        className="bold"
+        isActive={isMarkActive(marks["strong"], props.state)}
+        onClick={() =>
+          toggleMark(marks["strong"])(props.state, props.dispatchTransaction)
+        }
+      >
+        B
+      </Button>
+      <Button
+        className="italic"
+        isActive={isMarkActive(marks["em"], props.state)}
+        onClick={() =>
+          toggleMark(marks["em"])(props.state, props.dispatchTransaction)
+        }
+      >
+        I
+      </Button>
+    </div>
+  );
+}

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -15,23 +15,23 @@ function isMarkActive(mark: MarkType, state: EditorState): boolean {
 }
 
 export function Button(props: {
+  className?: string;
   children?: ReactNode;
   isActive: boolean;
-  className?: string;
-  title?: string;
+  title: string;
   onClick: () => void;
 }) {
-  function handleMouseDown(e: React.MouseEvent) {
-    e.preventDefault();
-    props.onClick();
-  }
+
   return (
     <button
+      type="button"
       title={props.title}
-      className={`button ${props.className} ${props.isActive ? "active" : ""}`}
-      onMouseDown={handleMouseDown}
+      aria-pressed={props.isActive}
+      className={`button ${props.className}`}
+      onClick={props.onClick}
     >
-      {props.children}
+      <span className="visually-hidden">{props.title}</span>
+      <span aria-hidden>{props.children}</span>
     </button>
   );
 }

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -19,6 +19,7 @@ export function Button(props: {
   children?: ReactNode;
   isActive: boolean;
   className?: string;
+  title?: string;
   onClick: () => void;
 }) {
   function handleMouseDown(e: React.MouseEvent) {
@@ -27,6 +28,7 @@ export function Button(props: {
   }
   return (
     <button
+      title={props.title}
       className={`button ${props.className} ${props.isActive ? "active" : ""}`}
       onMouseDown={handleMouseDown}
     >
@@ -37,6 +39,7 @@ export function Button(props: {
 
 export default function Menu() {
   const state = useEditorState();
+
   const { marks } = state.schema;
 
   const toggleBold = useEditorEventCallback((view) => {
@@ -55,6 +58,7 @@ export default function Menu() {
     <div className="menu">
       <Button
         className="bold"
+        title="Bold (⌘b)"
         isActive={isMarkActive(marks["strong"], state)}
         onClick={toggleBold}
       >
@@ -62,6 +66,7 @@ export default function Menu() {
       </Button>
       <Button
         className="italic"
+        title="Italic (⌘i)"
         isActive={isMarkActive(marks["em"], state)}
         onClick={toggleItalic}
       >

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -3,6 +3,8 @@ import type { MarkType } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import React, { ReactNode } from "react";
 
+import { useEditorEventCallback, useEditorState } from "../src/index.js";
+
 function isMarkActive(mark: MarkType, state: EditorState): boolean {
   if (!state.selection) return false;
   const { from, $from, to, empty } = state.selection;
@@ -31,28 +33,35 @@ export function Button(props: {
   );
 }
 
-export default function Menu(props: {
-  state: EditorState;
-  dispatchTransaction: (transaction: Transaction) => void;
-}) {
-  const { marks } = props.state.schema;
+export default function Menu() {
+  const state = useEditorState();
+  const { marks } = state.schema;
+
+  const toggleBold = useEditorEventCallback((view) => {
+    if (!view) return;
+    const toggleBoldMark = toggleMark(marks["bold"]);
+    toggleBoldMark(view.state, view.dispatch, view);
+  });
+
+  const toggleItalic = useEditorEventCallback((view) => {
+    if (!view) return;
+    const toggleBoldMark = toggleMark(marks["em"]);
+    toggleBoldMark(view.state, view.dispatch, view);
+  });
+
   return (
     <div className="menu">
       <Button
         className="bold"
-        isActive={isMarkActive(marks["strong"], props.state)}
-        onClick={() =>
-          toggleMark(marks["strong"])(props.state, props.dispatchTransaction)
-        }
+        isActive={isMarkActive(marks["strong"], state)}
+        onClick={toggleBold}
       >
         B
       </Button>
       <Button
         className="italic"
-        isActive={isMarkActive(marks["em"], props.state)}
-        onClick={() =>
-          toggleMark(marks["em"])(props.state, props.dispatchTransaction)
-        }
+        isActive={isMarkActive(marks["em"], state)}
+        onClick={toggleItalic}
       >
         I
       </Button>

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -5,6 +5,8 @@ import React, { ReactNode } from "react";
 
 import { useEditorEventCallback, useEditorState } from "../src/index.js";
 
+// lifted from:
+// https://github.com/ProseMirror/prosemirror-example-setup/blob/master/src/menu.ts#L58
 function isMarkActive(mark: MarkType, state: EditorState): boolean {
   if (!state.selection) return false;
   const { from, $from, to, empty } = state.selection;

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -8,7 +8,6 @@ import { useEditorEventCallback, useEditorState } from "../src/index.js";
 // lifted from:
 // https://github.com/ProseMirror/prosemirror-example-setup/blob/master/src/menu.ts#L58
 function isMarkActive(mark: MarkType, state: EditorState): boolean {
-  if (!state.selection) return false;
   const { from, $from, to, empty } = state.selection;
   return empty
     ? !!mark.isInSet(state.storedMarks || $from.marks())

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -48,8 +48,8 @@ export default function Menu() {
 
   const toggleItalic = useEditorEventCallback((view) => {
     if (!view) return;
-    const toggleBoldMark = toggleMark(view.state.schema.marks["em"]);
-    toggleBoldMark(view.state, view.dispatch, view);
+    const toggleItalicMark = toggleMark(view.state.schema.marks["em"]);
+    toggleItalicMark(view.state, view.dispatch, view);
   });
 
   return (

--- a/demo/main.css
+++ b/demo/main.css
@@ -1,5 +1,5 @@
 .ProseMirror {
-  border: thin solid black;
+  border: thin solid #ccc;
   border-radius: 0.25rem;
   padding: 1rem;
   outline: none;
@@ -10,4 +10,37 @@ main {
   margin: auto;
   width: 80%;
   max-width: 700px;
+}
+
+.menu {
+  display: flex;
+  margin-bottom: 5px;
+}
+
+.button {
+  cursor: pointer;
+  width: 36px;
+  height: 36px;
+  margin-right: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+  border: thin solid #ccc;
+  border-radius: 0.25rem;
+  color: black;
+  background-color: white;
+}
+
+.button.bold {
+  font-weight: 700;
+}
+
+.button.italic {
+  font-style: italic;
+}
+
+.button.active {
+  background-color: #DDD;
+  color: blue;
 }

--- a/demo/main.css
+++ b/demo/main.css
@@ -30,6 +30,11 @@ main {
   border-radius: 0.25rem;
   color: black;
   background-color: white;
+
+  &[aria-pressed='true'] {
+    background-color: #ddd;
+    color: blue;
+  }
 }
 
 .button.bold {
@@ -40,7 +45,12 @@ main {
   font-style: italic;
 }
 
-.button.active {
-  background-color: #ddd;
-  color: blue;
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/demo/main.css
+++ b/demo/main.css
@@ -41,6 +41,6 @@ main {
 }
 
 .button.active {
-  background-color: #DDD;
+  background-color: #ddd;
   color: blue;
 }

--- a/demo/main.css
+++ b/demo/main.css
@@ -31,7 +31,7 @@ main {
   color: black;
   background-color: white;
 
-  &[aria-pressed='true'] {
+  &[aria-pressed="true"] {
     background-color: #ddd;
     color: blue;
   }

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -5,6 +5,7 @@ import {
   liftEmptyBlock,
   newlineInCode,
   splitBlock,
+  toggleMark,
 } from "prosemirror-commands";
 import { keymap } from "prosemirror-keymap";
 import { Schema } from "prosemirror-model";
@@ -13,6 +14,7 @@ import { EditorState, Transaction } from "prosemirror-state";
 import "prosemirror-view/style/prosemirror.css";
 import React, { useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
+import Menu from "./Menu.js";
 
 import {
   NodeViewComponentProps,
@@ -31,6 +33,20 @@ const schema = new Schema({
     list: { group: "block", content: "list_item+" },
     list_item: { content: "paragraph+", toDOM: () => ["li", 0] },
     text: { group: "inline" },
+  },
+  marks: {
+    em: {
+      parseDOM: [{ tag: "em" }],
+      toDOM() {
+        return ["em", 0];
+      },
+    },
+    strong: {
+      parseDOM: [{ tag: "strong" }],
+      toDOM() {
+        return ["strong", 0];
+      },
+    },
   },
 });
 
@@ -54,6 +70,8 @@ const editorState = EditorState.create({
       ),
       "Shift-Enter": baseKeymap.Enter,
       "Shift-Tab": liftListItem(schema.nodes.list_item),
+      "Mod-b": toggleMark(schema.marks["strong"]),
+      "Mod-i": toggleMark(schema.marks["em"]),
     }),
     react(),
   ],
@@ -101,7 +119,7 @@ function DemoEditor() {
 
   return (
     <main>
-      <h1>React ProseMirror Demo</h1>
+      <Menu state={state} dispatchTransaction={dispatchTransaction} />
       <ProseMirror
         mount={mount}
         state={state}

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -15,8 +15,6 @@ import "prosemirror-view/style/prosemirror.css";
 import React, { useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import Menu from "./Menu.js";
-
 import {
   NodeViewComponentProps,
   ProseMirror,
@@ -24,6 +22,7 @@ import {
 } from "../src/index.js";
 import { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
 import { react } from "../src/plugins/react.js";
+import Menu from "./Menu.js";
 
 import "./main.css";
 

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -119,13 +119,13 @@ function DemoEditor() {
 
   return (
     <main>
-      <Menu state={state} dispatchTransaction={dispatchTransaction} />
       <ProseMirror
         mount={mount}
         state={state}
         nodeViews={nodeViews}
         dispatchTransaction={dispatchTransaction}
       >
+        <Menu />
         <div ref={setMount} />
         {renderNodeViews()}
       </ProseMirror>

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -22,8 +22,8 @@ import {
 } from "../src/index.js";
 import { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
 import { react } from "../src/plugins/react.js";
-import Menu from "./Menu.js";
 
+import Menu from "./Menu.js";
 import "./main.css";
 
 const schema = new Schema({

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -14,6 +14,7 @@ import { EditorState, Transaction } from "prosemirror-state";
 import "prosemirror-view/style/prosemirror.css";
 import React, { useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
+
 import Menu from "./Menu.js";
 
 import {


### PR DESCRIPTION
Hello!

This adds a menu to the demo. The intention is to show how to synchronize state from ProseMirror to React outside of the `<ProseMirror>` component hierarchy. Am I doing this right?

Features:
- Toggle bold and italic using React buttons that dispatches Transactions to the React managed EditorState.
- Derive the "active state" of the buttons using cursor positions that are derived from the EditorState

https://github.com/nytimes/react-prosemirror/assets/2272019/869da51d-f526-462b-b79b-47dbd4b0f9d2





