### PR TITLE
Makes EditorView non-nullable in `useLayoutGroupEffect` and `useEditorEventCallback`

### DIFF
--- a/.yarn/versions/25690ba0.yml
+++ b/.yarn/versions/25690ba0.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@nytimes/react-prosemirror"

--- a/.yarn/versions/25690ba0.yml
+++ b/.yarn/versions/25690ba0.yml
@@ -1,2 +1,2 @@
-undecided:
-  - "@nytimes/react-prosemirror"
+releases:
+  "@nytimes/react-prosemirror": minor

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ export function SelectionWidget() {
   const ref = useRef()
 
   useEditorEffect((view) => {
-    if (!view || !ref.current) return
+    if (!ref.current) return
 
     const viewClientRect = view.dom.getBoundingClientRect()
     const coords = view.coordsAtPos(view.state.selection.anchor))
@@ -576,7 +576,7 @@ export function SelectionWidget() {
   const ref = useRef()
 
   useEditorEffect((view) => {
-    if (!view || !ref.current) return
+    if (!ref.current) return
 
     const viewClientRect = view.dom.getBoundingClientRect()
     const coords = view.coordsAtPos(view.state.selection.anchor))

--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ import { useEditorEventCallback } from "@nytimes/react-prosemirror";
 
 export function BoldButton() {
   const onClick = useEditorEventCallback((view) => {
-    if (!view) return;
     const toggleBoldMark = toggleMark(view.state.schema.marks.bold);
     toggleBoldMark(view.state, view.dispatch, view);
   });

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -34,9 +34,7 @@ export function useEditorEffect(
   // be defined inline and run on every re-render.
   useLayoutGroupEffect(
     () => {
-      if (editorView) {
-        effect(editorView);
-      }
+      if (editorView) effect(editorView);
     },
     // The rules of hooks want to be able to statically
     // verify the dependencies for the effect, but this will

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -20,7 +20,7 @@ import { useLayoutGroupEffect } from "../contexts/LayoutGroup.js";
  * EditorView lives in an ancestor component.
  */
 export function useEditorEffect(
-  effect: (editorView: EditorView | null) => void | (() => void),
+  effect: (editorView: EditorView) => void | (() => void),
   dependencies?: DependencyList
 ) {
   const { editorView } = useContext(EditorContext);
@@ -33,7 +33,11 @@ export function useEditorEffect(
   // every time it changes, because it will most likely
   // be defined inline and run on every re-render.
   useLayoutGroupEffect(
-    () => effect(editorView),
+    () => {
+      if (editorView) {
+        effect(editorView);
+      }
+    },
     // The rules of hooks want to be able to statically
     // verify the dependencies for the effect, but this will
     // have already happened at the call-site.

--- a/src/hooks/useEditorEventCallback.ts
+++ b/src/hooks/useEditorEventCallback.ts
@@ -19,7 +19,7 @@ import { useEditorEffect } from "./useEditorEffect.js";
  * providers.
  */
 export function useEditorEventCallback<T extends unknown[], R>(
-  callback: (view: EditorView | null, ...args: T) => R
+  callback: (view: EditorView, ...args: T) => R
 ) {
   const ref = useRef(callback);
   const { editorView } = useContext(EditorContext);
@@ -29,7 +29,9 @@ export function useEditorEventCallback<T extends unknown[], R>(
   }, [callback]);
 
   return useCallback(
-    (...args: T) => ref.current(editorView, ...args),
+    (...args: T) => {
+      if (editorView) ref.current(editorView, ...args);
+    },
     [editorView]
   );
 }


### PR DESCRIPTION
## What?

Currently the `view` prop in `useLayoutGroupEffect` and `useEditorEventCallback` is nullable, this means that we need to assert that the value exists before using it:

```js
const onClick = useEditorEventCallback((view) => {
  if (view) {
    // do things
  }
});
```

By making the value non-nullable we no longer need this check!

## How?

This PR proposes that we only fire the  callbacks in the effects if `view` is set. This way we can guarantee that the value is never `null` and always of type `EditorView`.

So why is the value sometimes `null` in the first place? This has to do with how the initial render bootstraps the [EditorContext](https://github.com/nytimes/react-prosemirror/blob/main/src/contexts/EditorContext.ts) that holds the EditorView. See @smoores-dev [comment in this thread](https://github.com/nytimes/react-prosemirror/pull/81#discussion_r1466748866):

> On the first render pass, the view will be null, because it's constructed in a layout effect. That means that we sort of have to type the context as returning an optional view, even though in practice, I think it would always be defined by the time the callback actually runs.

For more details about how the creation of the EditorContext is deferred, see [useEditorView](https://github.com/nytimes/react-prosemirror/blob/main/src/hooks/useEditorView.ts#L105) 