### PR TITLE
Makes the return value of useEditorState non-nullable

### DIFF
--- a/.yarn/versions/53dfe063.yml
+++ b/.yarn/versions/53dfe063.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@nytimes/react-prosemirror"

--- a/.yarn/versions/53dfe063.yml
+++ b/.yarn/versions/53dfe063.yml
@@ -1,2 +1,2 @@
 releases:
-  "@nytimes/react-prosemirror": patch
+  "@nytimes/react-prosemirror": minor

--- a/.yarn/versions/53dfe063.yml
+++ b/.yarn/versions/53dfe063.yml
@@ -1,2 +1,2 @@
-undecided:
-  - "@nytimes/react-prosemirror"
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Note that components that use this hook must be descendants of the
 ### `useEditorState`
 
 ```tsx
-type useEditorState = () => EditorState | null;
+type useEditorState = () => EditorState;
 ```
 
 Provides access to the current EditorState value.

--- a/src/components/ProseMirrorInner.tsx
+++ b/src/components/ProseMirrorInner.tsx
@@ -53,7 +53,9 @@ export function ProseMirrorInner({
   });
 
   const editorState =
-    "state" in editorProps ? editorProps.state : editorView?.state ?? null;
+    "defaultState" in editorProps
+      ? editorProps.defaultState
+      : editorProps.state;
 
   const editorContextValue = useMemo(
     () => ({

--- a/src/components/ProseMirrorInner.tsx
+++ b/src/components/ProseMirrorInner.tsx
@@ -54,7 +54,8 @@ export function ProseMirrorInner({
 
   const editorState =
     "defaultState" in editorProps
-      ? editorProps.defaultState
+      ? // Only use the default state as a fallback for the first render where `editorView` isn't initialized yet
+        editorView?.state ?? editorProps.defaultState
       : editorProps.state;
 
   const editorContextValue = useMemo(

--- a/src/contexts/EditorContext.ts
+++ b/src/contexts/EditorContext.ts
@@ -6,7 +6,7 @@ import type { EventHandler } from "../plugins/componentEventListeners";
 
 interface EditorContextValue {
   editorView: EditorView | null;
-  editorState: EditorState | null;
+  editorState: EditorState;
   registerEventListener<EventType extends keyof DOMEventMap>(
     eventType: EventType,
     handler: EventHandler<EventType>

--- a/src/hooks/useEditorState.ts
+++ b/src/hooks/useEditorState.ts
@@ -6,7 +6,7 @@ import { EditorContext } from "../contexts/EditorContext.js";
 /**
  * Provides access to the current EditorState value.
  */
-export function useEditorState(): EditorState | null {
+export function useEditorState(): EditorState {
   const { editorState } = useContext(EditorContext);
 
   return editorState;

--- a/src/hooks/useNodePos.tsx
+++ b/src/hooks/useNodePos.tsx
@@ -13,7 +13,6 @@ const NodePosContext = createContext<number>(null as unknown as number);
 
 export function NodePosProvider({ nodeKey, children }: Props) {
   const editorState = useEditorState();
-  if (!editorState) return <>{children}</>;
   const pluginState = reactPluginKey.getState(editorState);
   if (!pluginState) return <>{children}</>;
   return (


### PR DESCRIPTION
Fixes https://github.com/nytimes/react-prosemirror/issues/82

I left a comment on the one-line change below. Am I missing something crucial here?