### PR TITLE
Remove unnecessary null guarding in the demo menu

### DIFF
--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -39,13 +39,11 @@ export default function Menu() {
   const state = useEditorState();
 
   const toggleBold = useEditorEventCallback((view) => {
-    if (!view) return;
     const toggleBoldMark = toggleMark(view.state.schema.marks["strong"]);
     toggleBoldMark(view.state, view.dispatch, view);
   });
 
   const toggleItalic = useEditorEventCallback((view) => {
-    if (!view) return;
     const toggleItalicMark = toggleMark(view.state.schema.marks["em"]);
     toggleItalicMark(view.state, view.dispatch, view);
   });
@@ -55,7 +53,7 @@ export default function Menu() {
       <Button
         className="bold"
         title="Bold (⌘b)"
-        isActive={!!state && isMarkActive(state.schema.marks["strong"], state)}
+        isActive={isMarkActive(state.schema.marks["strong"], state)}
         onClick={toggleBold}
       >
         B
@@ -63,7 +61,7 @@ export default function Menu() {
       <Button
         className="italic"
         title="Italic (⌘i)"
-        isActive={!!state && isMarkActive(state.schema.marks["em"], state)}
+        isActive={isMarkActive(state.schema.marks["em"], state)}
         onClick={toggleItalic}
       >
         I


### PR DESCRIPTION
A couple of changes to the demo menu (https://github.com/nytimes/react-prosemirror/pull/81) that removes unnecessary null guarding after incorporating the changes from 
https://github.com/nytimes/react-prosemirror/pull/84 and https://github.com/nytimes/react-prosemirror/pull/83