### PR TITLE
In the README.md example, create default editor state in the module scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ ProseMirror EditorView should be mounted on.
 
 ```tsx
 import { EditorState } from "prosemirror-state";
+import { schema } from "prosemirror-schema-basic";
 import { ProseMirror } from "@nytimes/react-prosemirror";
 
 const defaultState = EditorState.create({ schema });

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ ProseMirror EditorView should be mounted on.
 import { EditorState } from "prosemirror-state";
 import { ProseMirror } from "@nytimes/react-prosemirror";
 
+const defaultState = EditorState.create({ schema });
 export function ProseMirrorEditor() {
   // It's important that mount is stored as state,
   // rather than a ref, so that the ProseMirror component
@@ -103,7 +104,7 @@ export function ProseMirrorEditor() {
   const [mount, setMount] = useState<HTMLElement | null>(null);
 
   return (
-    <ProseMirror mount={mount} defaultState={EditorState.create({ schema })}>
+    <ProseMirror mount={mount} defaultState={defaultState}>
       <div ref={setMount} />
     </ProseMirror>
   );


### PR DESCRIPTION
This moves `EditorState.create` outside the React component so it's only instantiated once (as opposed to once per render).