### PR TITLE
Always call LayoutGroup effect destroy functions.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
   },
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
   "eslint.nodePath": ".yarn/sdks",
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
@@ -18,5 +17,6 @@
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.js"
 }

--- a/.yarn/sdks/prettier/index.js
+++ b/.yarn/sdks/prettier/index.js
@@ -17,4 +17,4 @@ if (existsSync(absPnpApiPath)) {
 }
 
 // Defer to the real prettier/index.js your application uses
-module.exports = absRequire(`prettier/index.js`);
+module.exports = absRequire(`prettier/index.cjs`);

--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "2.8.3-sdk",
+  "version": "3.2.5",
   "main": "./index.js",
   "type": "commonjs"
 }

--- a/.yarn/versions/8474c081.yml
+++ b/.yarn/versions/8474c081.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch


### PR DESCRIPTION
This resolves an issue where LayoutGroup effects were not cleaned up when the LayoutGroup itself was unmounted. React executes layout effect destroy functions from parent to child on unmount, which is opposite how it runs during normal render. The result was that the destroyQueue was never processed on unmount.

Now, if the LayoutGroup is being unmounted, we call destroy functions immediately, without queuing.

Note: This also fixes the Prettier config for VS Code, which got messed up when we upgraded to v3!