### PR TITLE
Return effect result from useEditorEffect.

### DIFF
--- a/.yarn/versions/00b65457.yml
+++ b/.yarn/versions/00b65457.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -34,7 +34,9 @@ export function useEditorEffect(
   // be defined inline and run on every re-render.
   useLayoutGroupEffect(
     () => {
-      if (editorView) effect(editorView);
+      if (editorView) {
+        return effect(editorView);
+      }
     },
     // The rules of hooks want to be able to statically
     // verify the dependencies for the effect, but this will


### PR DESCRIPTION
When we added a check for editorView before running effects from useEditorEffect, we unintentionally stopped returning the result from those effects. This resulted in never running effect destructors, which is incorrect.