### PR TITLE
Clean up imports by linting them for consistency and correctness

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,15 +16,19 @@
     "node": false
   },
   "rules": {
+    "@typescript-eslint/consistent-type-imports": "error",
     "no-console": ["error", { "allow": ["error"] }],
     "no-inner-declarations": "off",
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
     "import/extensions": ["error", "ignorePackages"],
+    "import/no-duplicates": ["error"],
     "import/no-unresolved": "off", // Typescript does this better!
     "import/order": [
       "error",
       {
         "alphabetize": {
-          "order": "asc"
+          "order": "asc",
+          "orderImportKind": "desc"
         },
         "newlines-between": "always",
         "warnOnUnassignedImports": true

--- a/.yarn/versions/59cd82f3.yml
+++ b/.yarn/versions/59cd82f3.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/demo/Menu.tsx
+++ b/demo/Menu.tsx
@@ -1,7 +1,8 @@
 import { toggleMark } from "prosemirror-commands";
 import type { MarkType } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
-import React, { ReactNode } from "react";
+import React from "react";
+import type { ReactNode } from "react";
 
 import { useEditorEventCallback, useEditorState } from "../src/index.js";
 

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -10,17 +10,15 @@ import {
 import { keymap } from "prosemirror-keymap";
 import { Schema } from "prosemirror-model";
 import { liftListItem, splitListItem } from "prosemirror-schema-list";
-import { EditorState, Transaction } from "prosemirror-state";
+import { EditorState } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
 import "prosemirror-view/style/prosemirror.css";
 import React, { useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import {
-  NodeViewComponentProps,
-  ProseMirror,
-  useNodeViews,
-} from "../src/index.js";
-import { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
+import { ProseMirror, useNodeViews } from "../src/index.js";
+import type { NodeViewComponentProps } from "../src/index.js";
+import type { ReactNodeViewConstructor } from "../src/nodeViews/createReactNodeViewConstructor.js";
 import { react } from "../src/plugins/react.js";
 
 import Menu from "./Menu.js";

--- a/src/components/__tests__/ProseMirror.test.tsx
+++ b/src/components/__tests__/ProseMirror.test.tsx
@@ -6,7 +6,7 @@ import type { Transaction } from "prosemirror-state";
 import React, { useEffect, useState } from "react";
 
 import { useNodeViews } from "../../hooks/useNodeViews.js";
-import { NodeViewComponentProps } from "../../nodeViews/createReactNodeViewConstructor.js";
+import type { NodeViewComponentProps } from "../../nodeViews/createReactNodeViewConstructor.js";
 import { react } from "../../plugins/react.js";
 import {
   setupProseMirrorView,

--- a/src/contexts/NodeViewsContext.ts
+++ b/src/contexts/NodeViewsContext.ts
@@ -1,4 +1,5 @@
-import { ReactPortal, createContext } from "react";
+import { createContext } from "react";
+import type { ReactPortal } from "react";
 
 import type { NodeKey } from "../plugins/react";
 

--- a/src/hooks/__tests__/useEditorViewLayoutEffect.test.tsx
+++ b/src/hooks/__tests__/useEditorViewLayoutEffect.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+
 import { render } from "@testing-library/react";
 import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";

--- a/src/hooks/__tests__/useNodeViews.test.tsx
+++ b/src/hooks/__tests__/useNodeViews.test.tsx
@@ -4,7 +4,7 @@ import { EditorState } from "prosemirror-state";
 import React, { createContext, useContext, useState } from "react";
 
 import { ProseMirror } from "../../components/ProseMirror.js";
-import { NodeViewComponentProps } from "../../nodeViews/createReactNodeViewConstructor.js";
+import type { NodeViewComponentProps } from "../../nodeViews/createReactNodeViewConstructor.js";
 import { react } from "../../plugins/react.js";
 import { useNodeViews } from "../useNodeViews.js";
 

--- a/src/hooks/useComponentEventListeners.tsx
+++ b/src/hooks/useComponentEventListeners.tsx
@@ -1,10 +1,8 @@
 import type { DOMEventMap } from "prosemirror-view";
 import { useCallback, useMemo, useState } from "react";
 
-import {
-  EventHandler,
-  componentEventListeners,
-} from "../plugins/componentEventListeners.js";
+import { componentEventListeners } from "../plugins/componentEventListeners.js";
+import type { EventHandler } from "../plugins/componentEventListeners.js";
 
 /**
  * Produces a plugin that can be used with ProseMirror to handle DOM

--- a/src/hooks/useNodePos.tsx
+++ b/src/hooks/useNodePos.tsx
@@ -1,6 +1,8 @@
-import React, { ReactNode, createContext, useContext } from "react";
+import React, { createContext, useContext } from "react";
+import type { ReactNode } from "react";
 
-import { NodeKey, reactPluginKey } from "../plugins/react.js";
+import { reactPluginKey } from "../plugins/react.js";
+import type { NodeKey } from "../plugins/react.js";
 
 import { useEditorState } from "./useEditorState.js";
 

--- a/src/hooks/useNodeViews.tsx
+++ b/src/hooks/useNodeViews.tsx
@@ -1,13 +1,16 @@
-import { EditorView } from "prosemirror-view";
-import React, { ReactPortal, useCallback, useMemo, useState } from "react";
+import type { EditorView } from "prosemirror-view";
+import React, { useCallback, useMemo, useState } from "react";
+import type { ReactPortal } from "react";
 
 import { NodeViews } from "../components/NodeViews.js";
 import type { NodeViewsContextValue } from "../contexts/NodeViewsContext.js";
 import {
-  ReactNodeViewConstructor,
-  RegisterPortal,
   createReactNodeViewConstructor,
   findNodeKeyUp,
+} from "../nodeViews/createReactNodeViewConstructor.js";
+import type {
+  ReactNodeViewConstructor,
+  RegisterPortal,
 } from "../nodeViews/createReactNodeViewConstructor.js";
 
 export function useNodeViews(

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -7,26 +7,29 @@ import type {
   NodeViewConstructor,
 } from "prosemirror-view";
 import React, {
-  Dispatch,
-  ReactPortal,
-  SetStateAction,
   forwardRef,
   useContext,
   useImperativeHandle,
   useState,
 } from "react";
-import type { ComponentType, ReactNode } from "react";
+import type {
+  ComponentType,
+  Dispatch,
+  ReactNode,
+  ReactPortal,
+  SetStateAction,
+} from "react";
 import { createPortal } from "react-dom";
 
 import { NodeViewsContext } from "../contexts/NodeViewsContext.js";
 import { useEditorEffect } from "../hooks/useEditorEffect.js";
 import { NodePosProvider } from "../hooks/useNodePos.js";
 import {
-  NodeKey,
   ROOT_NODE_KEY,
   createNodeKey,
   reactPluginKey,
 } from "../plugins/react.js";
+import type { NodeKey } from "../plugins/react.js";
 
 import { phrasingContentTags } from "./phrasingContentTags.js";
 

--- a/src/plugins/__tests__/react.test.ts
+++ b/src/plugins/__tests__/react.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import { findWrapping } from "prosemirror-transform";

--- a/src/plugins/componentEventListeners.ts
+++ b/src/plugins/componentEventListeners.ts
@@ -1,5 +1,5 @@
 import { Plugin, PluginKey } from "prosemirror-state";
-import { DOMEventMap, EditorView } from "prosemirror-view";
+import type { DOMEventMap, EditorView } from "prosemirror-view";
 import { unstable_batchedUpdates as batch } from "react-dom";
 
 export type EventHandler<


### PR DESCRIPTION
- Turn on @typescript-eslint/consistent-type-imports to ensure that all imports are correctly marked as type-only or runtime based on how they are used.

- Turn on import/consistent-type-specifier to ensure that type imports are always separate from value imports.

- Turn on import/no-duplicates.

- Order type imports after the runtime imports from a module.