### PR TITLE
Return the result from useEditorEventCallback

### DIFF
--- a/.yarn/versions/404a2ee9.yml
+++ b/.yarn/versions/404a2ee9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nytimes/react-prosemirror": patch

--- a/src/hooks/useEditorEventCallback.ts
+++ b/src/hooks/useEditorEventCallback.ts
@@ -30,7 +30,10 @@ export function useEditorEventCallback<T extends unknown[], R>(
 
   return useCallback(
     (...args: T) => {
-      if (editorView) ref.current(editorView, ...args);
+      if (editorView) {
+        return ref.current(editorView, ...args);
+      }
+      return;
     },
     [editorView]
   );


### PR DESCRIPTION
When we updated useEditorEventCallback to call its callback only when EditorView was set, we
unintentionally stopped returning its result.

This change simply goes back to always returning it.