### PR TITLE
setState and useEditorStateWithDispatch

### DIFF
--- a/src/contexts/EditorContext.ts
+++ b/src/contexts/EditorContext.ts
@@ -1,12 +1,13 @@
 import type { EditorState } from "prosemirror-state";
 import type { DOMEventMap, EditorView } from "prosemirror-view";
-import { createContext } from "react";
+import React, { createContext } from "react";
 
 import type { EventHandler } from "../plugins/componentEventListeners";
 
 export interface EditorContextValue {
   editorView: EditorView | null;
   editorState: EditorState;
+  setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
   registerEventListener<EventType extends keyof DOMEventMap>(
     eventType: EventType,
     handler: EventHandler<EventType>

--- a/src/hooks/useEditorState.ts
+++ b/src/hooks/useEditorState.ts
@@ -1,13 +1,20 @@
 import type { EditorState } from "prosemirror-state";
 import { useContext } from "react";
 
-import { EditorContext } from "../contexts/EditorContext.js";
+import { EditorContext, type EditorContextValue } from "../contexts/EditorContext.js";
 
 /**
  * Provides access to the current EditorState value.
  */
 export function useEditorState(): EditorState {
   const { editorState } = useContext(EditorContext);
-
   return editorState;
+}
+
+/**
+ * Provides access to the current EditorState value and method to update it.
+ */
+export function useEditorStateWithDispatch(): [EditorState, EditorContextValue['setEditorState']] {
+  const { editorState, setEditorState } = useContext(EditorContext);
+  return [editorState, setEditorState];
 }

--- a/src/hooks/useEditorView.ts
+++ b/src/hooks/useEditorView.ts
@@ -26,6 +26,7 @@ let didWarnValueDefaultValue = false;
 export interface UseEditorViewOptions extends EditorProps {
   defaultState?: EditorState;
   state?: EditorState;
+  setState?: EditorContextValue['setEditorState'];
   plugins?: Plugin[];
   dispatchTransaction?(this: EditorView, tr: Transaction): void;
 }
@@ -61,8 +62,9 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   }
 
   const defaultState = options.defaultState ?? EMPTY_STATE;
-  const [_state, setState] = useState<EditorState>(defaultState);
+  const [_state, _setState] = useState<EditorState>(defaultState);
   const state = options.state ?? _state;
+  const setState = options.setState ?? _setState;
 
   const {
     componentEventListenersPlugin,
@@ -121,10 +123,11 @@ export function useEditorView<T extends HTMLElement = HTMLElement>(
   return useMemo(
     () => ({
       editorState: state,
+      setEditorState: setState,
       editorView: view,
       registerEventListener,
       unregisterEventListener,
     }),
-    [state, view, registerEventListener, unregisterEventListener]
+    [state, setState, view, registerEventListener, unregisterEventListener]
   );
 }


### PR DESCRIPTION
- Adds `setState` as an optional prop.
- Exposes a `useEditorStateWithDispatch` that either uses that `setState` prop or the internal one.

Related to conversation here https://github.com/nytimes/react-prosemirror/issues/98#issuecomment-1942173437.
I've been finding myself doing dynamic registration of plugin states conditional on React components being rendered. `useEditorState` provides state only; if I wanted to update it, I would have to pass down the controlled `setState` or pass it down with a context. 

Decided to re-use the EditorContext instead.

