### PR TITLE
In a README examples, create the initial editor state only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ import { ProseMirror } from "@nytimes/react-prosemirror";
 
 export function ProseMirrorEditor() {
   const [mount, setMount] = useState<HTMLElement | null>(null);
-  const [state, setState] = useState(EditorState.create({ schema }));
+  const [state, setState] = useState(() => EditorState.create({ schema }));
 
   return (
     <ProseMirror
@@ -187,7 +187,7 @@ import { SelectionWidget } from "./SelectionWidget.tsx";
 
 export function ProseMirrorEditor() {
   const [mount, setMount] = useState<HTMLElement | null>(null);
-  const [state, setState] = useState(EditorState.create({ schema }))
+  const [state, setState] = useState(() => EditorState.create({ schema }))
 
   return (
     <ProseMirror
@@ -242,7 +242,7 @@ import { BoldButton } from "./BoldButton.tsx";
 
 export function ProseMirrorEditor() {
   const [mount, setMount] = useState<HTMLElement | null>(null);
-  const [state, setState] = useState(EditorState.create({ schema }));
+  const [state, setState] = useState(() => EditorState.create({ schema }));
 
   return (
     <ProseMirror


### PR DESCRIPTION
The code examples use react state with this example:

```javascript
const [state, setState] = useState(EditorState.create({ schema }));
```

With those examples, on every render, `EditorState.create` will be called.

To avoid that, we can use an initializer function ([documentation](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state)). In our case, we replace with:

```javascript
const [state, setState] = useState(() => EditorState.create({ schema }));
```