### PR TITLE
Fix bug with infinite rendering loop which can sometimes happen with widget decorations

### DIFF
--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -340,6 +340,14 @@ export function createReactNodeViewConstructor(
           componentRef?.setDecorations(decorations);
           return true;
         }
+        // Widget decorations can cause the NodeView's "update" hook to execute
+        // before the NodeViewWrapper component has mounted, and its ref set —
+        // in this situation, we tell ProseMirror that the update was successful
+        // in order to give time for React to propagate the ref, so that ProseMirror
+        // doesn't try to redraw this node forever.
+        if (componentRef === null) {
+          return true;
+        }
         return false;
       },
       destroy() {


### PR DESCRIPTION
We've seen an issue where rendering a widget decoration into an empty ProseMirror node with an associated react-prosemirror NodeView causes an infinite loop: the NodeView's `update` hook is called before the component's ref is set, which causes update to return `false`, which in turn causes ProseMirror to destroy and recreate the NodeView, repeating the cycle. The test committed here should illustrate the bug.

I'm feeling OK about the fix to the bug, even while I'll admit that I'm not totally sure I understand why this is happening: it's important to tell ProseMirror that an `update` either did update a node (returns `true`) or did not (returns `false`). At this point in the NodeView component code we should have reasonable confidence that this NodeView is responsible for a node at this position, even while we don't have the ref yet and so can't confirm that the Node's type matches the one passed down into the React `NodeViewWrapper`. By returning `true` here, a subsequent `update` cycle is called once the `ref` has been set, and the logic proceeds as it has been.

Some trailing observations:
- I still don't know why "render widget decoration into empty node" causes this — maybe widget rendering ends up triggering the update method earlier in relation to ReactDOM's rendering cyclle.
- I haven't confirmed whether this issue occurs on the v2.x flavor of `react-prosemirror`; my guess is that it probably does not, though, because the calling code responsible for destroying/recreating the NodeView in this scenario is non-React `prosemirror-view.EditorView` code.