### PR TITLE
Marking a 2.0 version

### DIFF
--- a/.yarn/versions/1266e9a0.yml
+++ b/.yarn/versions/1266e9a0.yml
@@ -1,2 +1,0 @@
-releases:
-  "@nytimes/react-prosemirror": major

--- a/.yarn/versions/a3c9f4be.yml
+++ b/.yarn/versions/a3c9f4be.yml
@@ -1,2 +1,0 @@
-releases:
-  "@nytimes/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nytimes/react-prosemirror",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This is a major release because there was a breaking change.