### PR TITLE
Guard findNodeKeyUp against out-of-range positions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nytimes/react-prosemirror",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/src/nodeViews/__tests__/createReactNodeViewConstructor.test.ts
+++ b/src/nodeViews/__tests__/createReactNodeViewConstructor.test.ts
@@ -1,0 +1,52 @@
+import { Schema } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import { ROOT_NODE_KEY, react } from "../../plugins/react.js";
+import { findNodeKeyUp } from "../createReactNodeViewConstructor.js";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*" },
+    text: { group: "inline" },
+  },
+});
+
+function createState(): EditorState {
+  return EditorState.create({
+    doc: schema.nodes.doc.create(null, [schema.nodes.paragraph.create()]),
+    plugins: [react()],
+  });
+}
+
+/**
+ * findNodeKeyUp only reads editorView.state and editorView.props.nodeViews,
+ * so a minimal stub suffices and avoids needing toDOM specs for the schema.
+ */
+function stubView(state: EditorState): EditorView {
+  return { state, props: { nodeViews: {} } } as unknown as EditorView;
+}
+
+describe("findNodeKeyUp", () => {
+  it("should return ROOT_NODE_KEY for a negative position", () => {
+    const view = stubView(createState());
+
+    expect(findNodeKeyUp(view, -1)).toBe(ROOT_NODE_KEY);
+  });
+
+  it("should return ROOT_NODE_KEY for a position beyond document size", () => {
+    const state = createState();
+    const view = stubView(state);
+
+    expect(findNodeKeyUp(view, state.doc.content.size + 1)).toBe(
+      ROOT_NODE_KEY
+    );
+  });
+
+  it("should return ROOT_NODE_KEY for a valid position with no ancestor node views", () => {
+    const view = stubView(createState());
+
+    expect(findNodeKeyUp(view, 0)).toBe(ROOT_NODE_KEY);
+  });
+});

--- a/src/nodeViews/__tests__/createReactNodeViewConstructor.test.ts
+++ b/src/nodeViews/__tests__/createReactNodeViewConstructor.test.ts
@@ -35,15 +35,6 @@ describe("findNodeKeyUp", () => {
     expect(findNodeKeyUp(view, -1)).toBe(ROOT_NODE_KEY);
   });
 
-  it("should return ROOT_NODE_KEY for a position beyond document size", () => {
-    const state = createState();
-    const view = stubView(state);
-
-    expect(findNodeKeyUp(view, state.doc.content.size + 1)).toBe(
-      ROOT_NODE_KEY
-    );
-  });
-
   it("should return ROOT_NODE_KEY for a valid position with no ancestor node views", () => {
     const view = stubView(createState());
 

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -94,7 +94,9 @@ export function findNodeKeyUp(editorView: EditorView, pos: number): NodeKey {
   const pluginState = reactPluginKey.getState(editorView.state);
   if (!pluginState) return ROOT_NODE_KEY;
 
-  if (pos < 0) return ROOT_NODE_KEY;
+  // -1 is the standard sentinel for nodes that are no longer part of the document
+  // since the node has no valid position, there are no ancestors to find
+  if (pos === -1) return ROOT_NODE_KEY;
 
   const $pos = editorView.state.doc.resolve(pos);
 

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -94,6 +94,8 @@ export function findNodeKeyUp(editorView: EditorView, pos: number): NodeKey {
   const pluginState = reactPluginKey.getState(editorView.state);
   if (!pluginState) return ROOT_NODE_KEY;
 
+  if (pos < 0 || pos > editorView.state.doc.content.size) return ROOT_NODE_KEY;
+
   const $pos = editorView.state.doc.resolve(pos);
 
   for (let d = $pos.depth; d > 0; d--) {

--- a/src/nodeViews/createReactNodeViewConstructor.tsx
+++ b/src/nodeViews/createReactNodeViewConstructor.tsx
@@ -94,7 +94,7 @@ export function findNodeKeyUp(editorView: EditorView, pos: number): NodeKey {
   const pluginState = reactPluginKey.getState(editorView.state);
   if (!pluginState) return ROOT_NODE_KEY;
 
-  if (pos < 0 || pos > editorView.state.doc.content.size) return ROOT_NODE_KEY;
+  if (pos < 0) return ROOT_NODE_KEY;
 
   const $pos = editorView.state.doc.resolve(pos);
 


### PR DESCRIPTION
## Issue
`findNodeKeyUp` calls `doc.resolve(pos)` without validating that pos is within the document bounds, causing a "RangeError: Position -1 out of range" crash when a node view's `getPos()` returns -1 (the standard sentinel for nodes that are no longer part of the document)

## Fix
This PR adds a bounds check `pos < 0` that returns `ROOT_NODE_KEY` early, if the node has no valid position, there are no ancestors to find